### PR TITLE
Makes status bar alignment configurable

### DIFF
--- a/package.json
+++ b/package.json
@@ -302,6 +302,15 @@
                     "default": null,
                     "description": "Specifies the date format of how absolute dates will be shown in the blame status bar. See https://momentjs.com/docs/#/displaying/format/ for valid formats"
                 },
+                "gitlens.statusBar.alignment": {
+                  "type": "string",
+                  "default": "right",
+                  "enum": [
+                    "left",
+                    "right"
+                  ],
+                  "description": "Specifies status bar alignment for blame information"
+                },
                 "gitlens.advanced.caching.enabled": {
                     "type": "boolean",
                     "default": true,

--- a/src/blameActiveLineController.ts
+++ b/src/blameActiveLineController.ts
@@ -61,7 +61,11 @@ export class BlameActiveLineController extends Disposable {
         if (!Objects.areEquivalent(config.statusBar, this._config && this._config.statusBar)) {
             changed = true;
             if (config.statusBar.enabled) {
-                this._statusBarItem = this._statusBarItem || window.createStatusBarItem(StatusBarAlignment.Right, 1000);
+                // coerce invalid configuration to the default right alignment
+                const useDefaultAlignment = config.statusBar.alignment === 'right' || config.statusBar.alignment !== 'left';
+                const alignment = useDefaultAlignment ? StatusBarAlignment.Right : StatusBarAlignment.Left;
+
+                this._statusBarItem = this._statusBarItem || window.createStatusBarItem(alignment, 1000);
                 this._statusBarItem.command = config.statusBar.command;
             }
             else if (!config.statusBar.enabled && this._statusBarItem) {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -91,6 +91,7 @@ export interface IStatusBarConfig {
     command: StatusBarCommand;
     date: 'off' | 'relative' | 'absolute';
     dateFormat: string;
+    alignment: 'left' | 'right';
 }
 
 export interface IAdvancedConfig {


### PR DESCRIPTION
Coming from [Git Blame](https://marketplace.visualstudio.com/items?itemName=waderyan.gitblame) I'm used to the blame info being on the left. It would be nice to have this option so I can replace Git Blame with GitLens in my [extension pack](https://marketplace.visualstudio.com/items?itemName=zackschuster.vscode-duck-extensions).

Thanks for your time!