### PR TITLE
Add link to remote commit

### DIFF
--- a/src/annotations/annotations.ts
+++ b/src/annotations/annotations.ts
@@ -63,7 +63,7 @@ export class Annotations {
                 .replace(/\n/g, '  \n');
             message = `\n\n> ${message}`;
         }
-        return `\`${commit.shortSha}\` &nbsp; __${commit.author}__, ${moment(commit.date).fromNow()} &nbsp; _(${moment(commit.date).format(dateFormat)})_${message}`;
+        return `[${commit.shortSha}](command:gitlens.openCommitInRemote) &nbsp; __${commit.author}__, ${moment(commit.date).fromNow()} &nbsp; _(${moment(commit.date).format(dateFormat)})_${message}`;
     }
 
     static getHoverDiffMessage(commit: GitCommit, previous: GitDiffLine | undefined, current: GitDiffLine | undefined): string | undefined {


### PR DESCRIPTION
Hi
Thank you for creating awesome extension 😄 

BTW, I think it is useful if we can open in remote by clicking commit.

![screen shot 2017-06-19 at 3 56 13](https://user-images.githubusercontent.com/1796864/27263416-8d4a775c-54a3-11e7-9c80-4fc00e0c7c82.png)

What do you think?