### PR TITLE
Use default VSCode behavior to open diff at first change

### DIFF
--- a/src/commands/diffWithPrevious.ts
+++ b/src/commands/diffWithPrevious.ts
@@ -56,14 +56,11 @@ export class DiffWithPreviousCommand extends ActiveEditorCommand {
                 this.git.getVersionedFile(args.commit.repoPath, args.commit.previousUri.fsPath, args.commit.previousSha)
             ]);
 
-            await commands.executeCommand(BuiltInCommands.Diff,
+            return await commands.executeCommand(BuiltInCommands.Diff,
                 Uri.file(lhs),
                 Uri.file(rhs),
                 `${path.basename(args.commit.previousUri.fsPath)} (${args.commit.previousShortSha}) ${GlyphChars.ArrowLeftRight} ${path.basename(args.commit.uri.fsPath)} (${args.commit.shortSha})`,
                 args.showOptions);
-
-            // TODO: Figure out how to focus the left pane
-            return await commands.executeCommand(BuiltInCommands.RevealLine, { lineNumber: args.line, at: 'center' });
         }
         catch (ex) {
             Logger.error(ex, 'DiffWithPreviousCommand', 'getVersionedFile');


### PR DESCRIPTION
When selecting "Compare File with Previous" the experience is very jumpy as it renders the diff to the first set of changes and then returns the user back to their current line position. Since Gitlens also supports "Compare Line Commit with Previous" I think the experience would be much better if opening the diff took the user to the first set of diff changes. Unfortunately it looks like there is an `position` option that is not exposed to extensions.

https://sourcegraph.com/github.com/Microsoft/vscode/-/blob/src/vs/workbench/electron-browser/commands.ts#L397-399:83
```
CommandsRegistry.registerCommand('_workbench.diff', function (accessor: ServicesAccessor, args: [URI, URI, string, string, IEditorOptions, EditorPosition]) {
     const editorService = accessor.get(IWorkbenchEditorService);
     let [leftResource, rightResource, label, description, options, position] = args;
```