### PR TITLE
Only show remote and details command and diff message where applicable

### DIFF
--- a/src/annotations/annotations.ts
+++ b/src/annotations/annotations.ts
@@ -53,7 +53,11 @@ export class Annotations {
         }
 
         let message = '';
+        let openInRemoteCommand = '';
+        let showCommitDetailsCommand = '';
         if (!commit.isUncommitted) {
+            if (hasRemotes) openInRemoteCommand = `${'&nbsp;'.repeat(3)} [\`${GlyphChars.ArrowUpRight}\`](${OpenCommitInRemoteCommand.getMarkdownCommandArgs(commit.sha)} "Open in Remote") &nbsp; `;
+            showCommitDetailsCommand = `[\`${commit.shortSha}\`](${ShowQuickCommitDetailsCommand.getMarkdownCommandArgs(commit.sha)} "Show Commit Details") &nbsp; `;
             message = commit.message
                 // Escape markdown
                 .replace(escapeMarkdownRegEx, '\\$&')
@@ -64,17 +68,13 @@ export class Annotations {
             message = `\n\n> ${message}`;
         }
 
-        const openInRemoteCommand = hasRemotes
-            ? `${'&nbsp;'.repeat(3)} [\`${GlyphChars.ArrowUpRight}\`](${OpenCommitInRemoteCommand.getMarkdownCommandArgs(commit.sha)} "Open in Remote")`
-            : '';
-
-        const markdown = new MarkdownString(`[\`${commit.shortSha}\`](${ShowQuickCommitDetailsCommand.getMarkdownCommandArgs(commit.sha)} "Show Commit Details") &nbsp; __${commit.author}__, ${commit.fromNow()} &nbsp; _(${commit.formatDate(dateFormat)})_ ${openInRemoteCommand} &nbsp; ${message}`);
+        const markdown = new MarkdownString(`${showCommitDetailsCommand}__${commit.author}__, ${commit.fromNow()} &nbsp; _(${commit.formatDate(dateFormat)})_ ${openInRemoteCommand}${message}`);
         markdown.isTrusted = true;
         return markdown;
     }
 
     static getHoverDiffMessage(commit: GitCommit, chunkLine: GitDiffChunkLine | undefined): MarkdownString | undefined {
-        if (chunkLine === undefined) return undefined;
+        if (chunkLine === undefined || commit.previousSha === undefined) return undefined;
 
         const codeDiff = this._getCodeDiff(chunkLine);
         const markdown = new MarkdownString(commit.isUncommitted


### PR DESCRIPTION
Only show the `Open in Remote` and `Show Commit Details` when the change is committed.
Only show a diff message when there is a previous version available.

Achieved by: 
- The removal of the `Open in Remote` and `Show Commit Details` commands for uncomitted changes.
Clicking the left one tells you that the commit couldn't be found.
Clicking the right one links you to a 404 page as `0000000000000000000000000000000000000000` is not a valid hash.
![grafik](https://user-images.githubusercontent.com/24881032/31102225-76c405b2-a7d1-11e7-9e2a-be9fffb605e9.png)


- The removal of the diff message when there is no previous commit available (e.g. the line was never changed after comitting the file).
The previous commit hash is displayed as `undefined` and clicking it is the same as clicking the right one.
Clicking on Changes errors out as there is no old hash to compare.
The diff is also not quite right, it displays the "new" one for both.
![grafik](https://user-images.githubusercontent.com/24881032/31102475-9249bccc-a7d2-11e7-9f03-745235f1ff8f.png)
This is similar to a completely uncomitted file which displays as the following:
![grafik](https://user-images.githubusercontent.com/24881032/31102901-799eec86-a7d4-11e7-85fd-c0469c69e6c2.png)
 
