### PR TITLE
support for non https remotes

### DIFF
--- a/src/git/remotes/provider.ts
+++ b/src/git/remotes/provider.ts
@@ -40,6 +40,7 @@ export abstract class RemoteProvider {
         public readonly domain: string,
         public readonly path: string,
         name?: string,
+        public readonly protocol: string = 'https'
         public readonly custom: boolean = false
     ) {
         this._name = name;
@@ -48,7 +49,7 @@ export abstract class RemoteProvider {
     abstract get name(): string;
 
     protected get baseUrl() {
-        return `https://${this.domain}/${this.path}`;
+      return `${this.protocol}://${this.domain}/${this.path}`;
     }
 
     protected formatName(name: string) {


### PR DESCRIPTION
hey, thx for this awesome plugin ❤️  

we have a gitlab instance running without https -> don't ask!

here is the required change to support the http protocol (and keep the default `https`; works for all remotes) 


config sample:

```
{
    "gitlens.remotes": [{ "domain": "gitlab.xxxx.at", "type": "GitLab", "protocol": "http" }]
}
```

let me know if there is something to change/adapt.