### PR TITLE
Tuned blame line highlighting

### DIFF
--- a/src/annotations/blameAnnotationProvider.ts
+++ b/src/annotations/blameAnnotationProvider.ts
@@ -57,7 +57,7 @@ export abstract class BlameAnnotationProviderBase extends AnnotationProviderBase
         }
 
         const highlightDecorationRanges = Arrays.filterMap(blame.lines,
-            l => l.sha !== sha ? this.editor.document.validateRange(new Range(l.line, 0, l.line, 1000000)) : undefined);
+            l => l.sha === sha ? this.editor.document.validateRange(new Range(l.line, 0, l.line, 1000000)) : undefined);
 
         this.editor.setDecorations(this.highlightDecoration, highlightDecorationRanges);
     }


### PR DESCRIPTION
Added small fix to invert git blame line highlighting. When you select the line GitLens highlights all commits except that which you selected. I'm just inverted this.