### PR TITLE
Add new command to diff HEAD with branch using command palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -1096,6 +1096,11 @@
                 "category": "GitLens"
             },
             {
+                "command": "gitlens.diffHeadWithBranch",
+                "title": "Compare Index (HEAD) with Branch or Tag...",
+                "category": "GitLens"
+            },
+            {
                 "command": "gitlens.diffWith",
                 "title": "Compare File Revisions",
                 "category": "GitLens"
@@ -1631,6 +1636,10 @@
             "commandPalette": [
                 {
                     "command": "gitlens.diffDirectory",
+                    "when": "gitlens:enabled"
+                },
+                {
+                    "command": "gitlens.diffHeadWithBranch",
                     "when": "gitlens:enabled"
                 },
                 {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -9,6 +9,7 @@ export * from './commands/closeUnchangedFiles';
 export * from './commands/copyMessageToClipboard';
 export * from './commands/copyShaToClipboard';
 export * from './commands/diffDirectory';
+export * from './commands/diffHeadWithBranch';
 export * from './commands/diffLineWithPrevious';
 export * from './commands/diffLineWithWorking';
 export * from './commands/diffWith';
@@ -59,6 +60,7 @@ export function configureCommands(): void {
     Container.context.subscriptions.push(new Commands.CopyMessageToClipboardCommand());
     Container.context.subscriptions.push(new Commands.CopyShaToClipboardCommand());
     Container.context.subscriptions.push(new Commands.DiffDirectoryCommand());
+    Container.context.subscriptions.push(new Commands.DiffHeadWithBranchCommand());
     Container.context.subscriptions.push(new Commands.DiffLineWithPreviousCommand());
     Container.context.subscriptions.push(new Commands.DiffLineWithWorkingCommand());
     Container.context.subscriptions.push(new Commands.DiffWithCommand());

--- a/src/commands/common.ts
+++ b/src/commands/common.ts
@@ -12,6 +12,7 @@ export enum Commands {
     CopyMessageToClipboard = 'gitlens.copyMessageToClipboard',
     CopyShaToClipboard = 'gitlens.copyShaToClipboard',
     DiffDirectory = 'gitlens.diffDirectory',
+    DiffHeadWithBranch = 'gitlens.diffHeadWithBranch',
     ExternalDiffAll = 'gitlens.externalDiffAll',
     DiffWith = 'gitlens.diffWith',
     DiffWithBranch = 'gitlens.diffWithBranch',

--- a/src/commands/diffHeadWithBranch.ts
+++ b/src/commands/diffHeadWithBranch.ts
@@ -1,0 +1,54 @@
+'use strict';
+import { CancellationTokenSource, TextEditor, Uri, window } from 'vscode';
+import { ActiveEditorCommand, Commands, getCommandUri } from './common';
+import { GlyphChars } from '../constants';
+import { Container } from '../container';
+import { Logger } from '../logger';
+import { Messages } from '../messages';
+import { BranchesAndTagsQuickPick, CommandQuickPickItem } from '../quickPicks';
+
+export class DiffHeadWithBranchCommand extends ActiveEditorCommand {
+
+    constructor() {
+        super([Commands.DiffHeadWithBranch]);
+    }
+
+    async execute(editor?: TextEditor, uri?: Uri): Promise<any> {
+        uri = getCommandUri(uri, editor);
+
+        let progressCancellation: CancellationTokenSource | undefined;
+
+        try {
+            const repoPath = await Container.git.getRepoPath(uri);
+            if (!repoPath) return Messages.showNoRepositoryWarningMessage(`Unable to open directory compare`);
+
+            const placeHolder = `Compare Index (HEAD) to ${GlyphChars.Ellipsis}`;
+
+            progressCancellation = BranchesAndTagsQuickPick.showProgress(placeHolder);
+
+            const [branches, tags] = await Promise.all([
+                Container.git.getBranches(repoPath),
+                Container.git.getTags(repoPath)
+            ]);
+
+            if (progressCancellation.token.isCancellationRequested) return undefined;
+
+            const pick = await BranchesAndTagsQuickPick.show(branches, tags, placeHolder, { progressCancellation: progressCancellation });
+            if (pick === undefined) return undefined;
+
+            if (pick instanceof CommandQuickPickItem) return pick.execute();
+
+            const compareWith = pick.name;
+            if (compareWith === undefined) return undefined;
+
+            Container.resultsExplorer.showComparisonInResults(repoPath, compareWith, 'HEAD');
+
+            return undefined;
+        } catch (ex) {
+            Logger.error(ex, 'DiffHeadWithBranchCommand');
+            return window.showErrorMessage(`Unable to open directory compare. See output channel for more details`);
+        } finally {
+            progressCancellation && progressCancellation.dispose();
+        }
+    }
+}


### PR DESCRIPTION
Hi 👋 
First thank you for your awesome plugin, I felt in love with it ❤️ 

However, these days something tickled me a little bit. I thought the workflow to compare HEAD with another branch (like comparing feature branches with master for checking colleagues Pull Requests) was a bit unfriendly (especially for people without the GitLens panel in explorer) 😅 

I thought something like _Cmd + P > Compare HEAD with ... (master)_ would be very cool.
You already made that but to use yours we need to have an external difftool configured 😢 
That's sad because you already made one awesome difftool included in Code to compare branches : I name it : "GitLens result panel".

That's it ! Just have to mix **Command Palette** and **GitLens result panel** to have an awesome workflow. 
I tried to cook something on a branch, that's works very well. It would be great to share this with everyone don't you think ? 👍 

## Tech Part
I decided to create a new command not to modify directly `diffDirectory.ts` to avoid "spaghetti code". However I'm not a **genius**, neither the **owner of GitLens** (are these synonym ? 😄) so if you prefer another approach I'll be glad to modify my branch to satisfy your needs. 👍 
Just tell me what to modify to make this better than it is 🥇 
Once you ok with this feature, I'll update the README accordingly 😀

Have a nice day !