### PR TITLE
Support Linux without requiring external dependency (xclip)

### DIFF
--- a/README.md
+++ b/README.md
@@ -797,11 +797,6 @@ GitLens defines a set of themable colors which can be provided by vscode themes 
 Add [`"gitlens.insiders": true`](#general-settings "Jump to GitLens settings") to your settings to join the insiders channel and get early access to upcoming features. Be aware that because this provides early access expect there to be issues.
 
 ---
-## Known Issues
-
-- If the `Copy to * clipboard` commands don't work on Linux &mdash; `xclip` needs to be installed. You can install it via `sudo apt-get install xclip`
-
----
 ## Contributors &#x1F64F;&#x2764;
 
 A big thanks to the people that have contributed to this project:

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,10 +4,10 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
-        "@types/copy-paste": {
-            "version": "1.1.30",
-            "resolved": "https://registry.npmjs.org/@types/copy-paste/-/copy-paste-1.1.30.tgz",
-            "integrity": "sha1-p9RUyeHkVCMo9/Huz1Mzvoz7UO0=",
+        "@types/clipboardy": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@types/clipboardy/-/clipboardy-1.1.0.tgz",
+            "integrity": "sha512-KOxf4ah9diZWmREM5jCupx2+pZaBPwKk5d5jeNK2+TY6IgEO35uhG55NnDT4cdXeRX8irDSHQPtdRrr0JOTQIw==",
             "dev": true
         },
         "@types/node": {
@@ -31,8 +31,8 @@
                 "@webassemblyjs/helper-module-context": "1.5.9",
                 "@webassemblyjs/helper-wasm-bytecode": "1.5.9",
                 "@webassemblyjs/wast-parser": "1.5.9",
-                "debug": "^3.1.0",
-                "mamacro": "^0.0.3"
+                "debug": "3.1.0",
+                "mamacro": "0.0.3"
             },
             "dependencies": {
                 "debug": {
@@ -64,7 +64,7 @@
             "integrity": "sha512-WYkys6y33viEY23tHJ+KkSd9yHZBd54Sy6gcSgwLGPP1or9pLqWBrjWWATHuDuIkpvSJSt/+3qjAV6zHd1nS0g==",
             "dev": true,
             "requires": {
-                "debug": "^3.1.0"
+                "debug": "3.1.0"
             },
             "dependencies": {
                 "debug": {
@@ -115,7 +115,7 @@
                 "@webassemblyjs/helper-buffer": "1.5.9",
                 "@webassemblyjs/helper-wasm-bytecode": "1.5.9",
                 "@webassemblyjs/wasm-gen": "1.5.9",
-                "debug": "^3.1.0"
+                "debug": "3.1.0"
             },
             "dependencies": {
                 "debug": {
@@ -135,7 +135,7 @@
             "integrity": "sha512-mhetZBDnpV3VYqZb5Aail9X01VyIqDDZrNYdYj8bfx/PsVPG2znX90wRyVNTeqC5ylqHCgGkJ63bPaPEyINfsw==",
             "dev": true,
             "requires": {
-                "ieee754": "^1.1.11"
+                "ieee754": "1.1.11"
             }
         },
         "@webassemblyjs/leb128": {
@@ -144,7 +144,7 @@
             "integrity": "sha512-oZ3eUB9EViUtiuMwW/xeYamXgfFS2cmXl6aUIYBfpXJQ5v5aOC8ZuPpz2/LqlgNlT8ThpyFd6kfgkYVwKwkGvQ==",
             "dev": true,
             "requires": {
-                "leb": "^0.3.0"
+                "leb": "0.3.0"
             }
         },
         "@webassemblyjs/wasm-edit": {
@@ -161,7 +161,7 @@
                 "@webassemblyjs/wasm-opt": "1.5.9",
                 "@webassemblyjs/wasm-parser": "1.5.9",
                 "@webassemblyjs/wast-printer": "1.5.9",
-                "debug": "^3.1.0"
+                "debug": "3.1.0"
             },
             "dependencies": {
                 "debug": {
@@ -197,7 +197,7 @@
                 "@webassemblyjs/helper-buffer": "1.5.9",
                 "@webassemblyjs/wasm-gen": "1.5.9",
                 "@webassemblyjs/wasm-parser": "1.5.9",
-                "debug": "^3.1.0"
+                "debug": "3.1.0"
             },
             "dependencies": {
                 "debug": {
@@ -236,8 +236,8 @@
                 "@webassemblyjs/helper-api-error": "1.5.9",
                 "@webassemblyjs/helper-code-frame": "1.5.9",
                 "@webassemblyjs/helper-fsm": "1.5.9",
-                "long": "^3.2.0",
-                "mamacro": "^0.0.3"
+                "long": "3.2.0",
+                "mamacro": "0.0.3"
             }
         },
         "@webassemblyjs/wast-printer": {
@@ -248,7 +248,7 @@
             "requires": {
                 "@webassemblyjs/ast": "1.5.9",
                 "@webassemblyjs/wast-parser": "1.5.9",
-                "long": "^3.2.0"
+                "long": "3.2.0"
             }
         },
         "acorn": {
@@ -263,7 +263,7 @@
             "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
             "dev": true,
             "requires": {
-                "acorn": "^5.0.0"
+                "acorn": "5.6.1"
             }
         },
         "ajv": {
@@ -272,10 +272,10 @@
             "integrity": "sha512-VDUX1oSajablmiyFyED9L1DFndg0P9h7p1F+NO8FkIzei6EPrR6Zu1n18rd5P8PqaSRd/FrWv3G1TVBqpM83gA==",
             "dev": true,
             "requires": {
-                "fast-deep-equal": "^2.0.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.3.0",
-                "uri-js": "^4.2.1"
+                "fast-deep-equal": "2.0.1",
+                "fast-json-stable-stringify": "2.0.0",
+                "json-schema-traverse": "0.3.1",
+                "uri-js": "4.2.2"
             }
         },
         "ajv-keywords": {
@@ -320,7 +320,7 @@
             "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
             "dev": true,
             "requires": {
-                "color-convert": "^1.9.0"
+                "color-convert": "1.9.1"
             }
         },
         "ansi-wrap": {
@@ -335,8 +335,8 @@
             "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
             "dev": true,
             "requires": {
-                "micromatch": "^3.1.4",
-                "normalize-path": "^2.1.1"
+                "micromatch": "3.1.10",
+                "normalize-path": "2.1.1"
             },
             "dependencies": {
                 "normalize-path": {
@@ -345,7 +345,7 @@
                     "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
                     "dev": true,
                     "requires": {
-                        "remove-trailing-separator": "^1.0.1"
+                        "remove-trailing-separator": "1.1.0"
                     }
                 }
             }
@@ -356,13 +356,18 @@
             "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
             "dev": true
         },
+        "arch": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.0.tgz",
+            "integrity": "sha1-NhOqRhSQZLPB8GB5Gb8dR4boKIk="
+        },
         "argparse": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "dev": true,
             "requires": {
-                "sprintf-js": "~1.0.2"
+                "sprintf-js": "1.0.3"
             }
         },
         "arr-diff": {
@@ -401,7 +406,7 @@
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "dev": true,
             "requires": {
-                "array-uniq": "^1.0.1"
+                "array-uniq": "1.0.3"
             }
         },
         "array-uniq": {
@@ -434,9 +439,9 @@
             "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
             "dev": true,
             "requires": {
-                "bn.js": "^4.0.0",
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0"
+                "bn.js": "4.11.8",
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.1"
             }
         },
         "assert": {
@@ -496,9 +501,9 @@
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
             "dev": true,
             "requires": {
-                "chalk": "^1.1.3",
-                "esutils": "^2.0.2",
-                "js-tokens": "^3.0.2"
+                "chalk": "1.1.3",
+                "esutils": "2.0.2",
+                "js-tokens": "3.0.2"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -513,11 +518,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
                     }
                 },
                 "supports-color": {
@@ -540,13 +545,13 @@
             "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
             "dev": true,
             "requires": {
-                "cache-base": "^1.0.1",
-                "class-utils": "^0.3.5",
-                "component-emitter": "^1.2.1",
-                "define-property": "^1.0.0",
-                "isobject": "^3.0.1",
-                "mixin-deep": "^1.2.0",
-                "pascalcase": "^0.1.1"
+                "cache-base": "1.0.1",
+                "class-utils": "0.3.6",
+                "component-emitter": "1.2.1",
+                "define-property": "1.0.0",
+                "isobject": "3.0.1",
+                "mixin-deep": "1.3.1",
+                "pascalcase": "0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -555,7 +560,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^1.0.0"
+                        "is-descriptor": "1.0.2"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -564,7 +569,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -573,7 +578,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -582,9 +587,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
                     }
                 }
             }
@@ -602,7 +607,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "tweetnacl": "^0.14.3"
+                "tweetnacl": "0.14.5"
             }
         },
         "big.js": {
@@ -623,7 +628,7 @@
             "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
             "dev": true,
             "requires": {
-                "inherits": "~2.0.0"
+                "inherits": "2.0.3"
             }
         },
         "bluebird": {
@@ -644,7 +649,7 @@
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dev": true,
             "requires": {
-                "balanced-match": "^1.0.0",
+                "balanced-match": "1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -654,16 +659,16 @@
             "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
             "dev": true,
             "requires": {
-                "arr-flatten": "^1.1.0",
-                "array-unique": "^0.3.2",
-                "extend-shallow": "^2.0.1",
-                "fill-range": "^4.0.0",
-                "isobject": "^3.0.1",
-                "repeat-element": "^1.1.2",
-                "snapdragon": "^0.8.1",
-                "snapdragon-node": "^2.0.1",
-                "split-string": "^3.0.2",
-                "to-regex": "^3.0.1"
+                "arr-flatten": "1.1.0",
+                "array-unique": "0.3.2",
+                "extend-shallow": "2.0.1",
+                "fill-range": "4.0.0",
+                "isobject": "3.0.1",
+                "repeat-element": "1.1.2",
+                "snapdragon": "0.8.2",
+                "snapdragon-node": "2.1.1",
+                "split-string": "3.1.0",
+                "to-regex": "3.0.2"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -672,7 +677,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 }
             }
@@ -695,12 +700,12 @@
             "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
             "dev": true,
             "requires": {
-                "buffer-xor": "^1.0.3",
-                "cipher-base": "^1.0.0",
-                "create-hash": "^1.1.0",
-                "evp_bytestokey": "^1.0.3",
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.0.1"
+                "buffer-xor": "1.0.3",
+                "cipher-base": "1.0.4",
+                "create-hash": "1.2.0",
+                "evp_bytestokey": "1.0.3",
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.2"
             }
         },
         "browserify-cipher": {
@@ -709,9 +714,9 @@
             "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
             "dev": true,
             "requires": {
-                "browserify-aes": "^1.0.4",
-                "browserify-des": "^1.0.0",
-                "evp_bytestokey": "^1.0.0"
+                "browserify-aes": "1.2.0",
+                "browserify-des": "1.0.1",
+                "evp_bytestokey": "1.0.3"
             }
         },
         "browserify-des": {
@@ -720,9 +725,9 @@
             "integrity": "sha512-zy0Cobe3hhgpiOM32Tj7KQ3Vl91m0njwsjzZQK1L+JDf11dzP9qIvjreVinsvXrgfjhStXwUWAEpB9D7Gwmayw==",
             "dev": true,
             "requires": {
-                "cipher-base": "^1.0.1",
-                "des.js": "^1.0.0",
-                "inherits": "^2.0.1"
+                "cipher-base": "1.0.4",
+                "des.js": "1.0.0",
+                "inherits": "2.0.3"
             }
         },
         "browserify-rsa": {
@@ -731,8 +736,8 @@
             "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
             "dev": true,
             "requires": {
-                "bn.js": "^4.1.0",
-                "randombytes": "^2.0.1"
+                "bn.js": "4.11.8",
+                "randombytes": "2.0.6"
             }
         },
         "browserify-sign": {
@@ -741,13 +746,13 @@
             "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
             "dev": true,
             "requires": {
-                "bn.js": "^4.1.1",
-                "browserify-rsa": "^4.0.0",
-                "create-hash": "^1.1.0",
-                "create-hmac": "^1.1.2",
-                "elliptic": "^6.0.0",
-                "inherits": "^2.0.1",
-                "parse-asn1": "^5.0.0"
+                "bn.js": "4.11.8",
+                "browserify-rsa": "4.0.1",
+                "create-hash": "1.2.0",
+                "create-hmac": "1.1.7",
+                "elliptic": "6.4.0",
+                "inherits": "2.0.3",
+                "parse-asn1": "5.1.1"
             }
         },
         "browserify-zlib": {
@@ -756,7 +761,7 @@
             "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
             "dev": true,
             "requires": {
-                "pako": "~1.0.5"
+                "pako": "1.0.6"
             }
         },
         "buffer": {
@@ -765,9 +770,9 @@
             "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
             "dev": true,
             "requires": {
-                "base64-js": "^1.0.2",
-                "ieee754": "^1.1.4",
-                "isarray": "^1.0.0"
+                "base64-js": "1.3.0",
+                "ieee754": "1.1.11",
+                "isarray": "1.0.0"
             }
         },
         "buffer-crc32": {
@@ -806,19 +811,19 @@
             "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
             "dev": true,
             "requires": {
-                "bluebird": "^3.5.1",
-                "chownr": "^1.0.1",
-                "glob": "^7.1.2",
-                "graceful-fs": "^4.1.11",
-                "lru-cache": "^4.1.1",
-                "mississippi": "^2.0.0",
-                "mkdirp": "^0.5.1",
-                "move-concurrently": "^1.0.1",
-                "promise-inflight": "^1.0.1",
-                "rimraf": "^2.6.2",
-                "ssri": "^5.2.4",
-                "unique-filename": "^1.1.0",
-                "y18n": "^4.0.0"
+                "bluebird": "3.5.1",
+                "chownr": "1.0.1",
+                "glob": "7.1.2",
+                "graceful-fs": "4.1.11",
+                "lru-cache": "4.1.3",
+                "mississippi": "2.0.0",
+                "mkdirp": "0.5.1",
+                "move-concurrently": "1.0.1",
+                "promise-inflight": "1.0.1",
+                "rimraf": "2.6.2",
+                "ssri": "5.3.0",
+                "unique-filename": "1.1.0",
+                "y18n": "4.0.0"
             }
         },
         "cache-base": {
@@ -827,15 +832,15 @@
             "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
             "dev": true,
             "requires": {
-                "collection-visit": "^1.0.0",
-                "component-emitter": "^1.2.1",
-                "get-value": "^2.0.6",
-                "has-value": "^1.0.0",
-                "isobject": "^3.0.1",
-                "set-value": "^2.0.0",
-                "to-object-path": "^0.3.0",
-                "union-value": "^1.0.0",
-                "unset-value": "^1.0.0"
+                "collection-visit": "1.0.0",
+                "component-emitter": "1.2.1",
+                "get-value": "2.0.6",
+                "has-value": "1.0.0",
+                "isobject": "3.0.1",
+                "set-value": "2.0.0",
+                "to-object-path": "0.3.0",
+                "union-value": "1.0.0",
+                "unset-value": "1.0.0"
             }
         },
         "camelcase": {
@@ -856,9 +861,9 @@
             "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
             "dev": true,
             "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
+                "ansi-styles": "3.2.1",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "5.4.0"
             }
         },
         "chardet": {
@@ -873,18 +878,18 @@
             "integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
             "dev": true,
             "requires": {
-                "anymatch": "^2.0.0",
-                "async-each": "^1.0.0",
-                "braces": "^2.3.0",
-                "fsevents": "^1.1.2",
-                "glob-parent": "^3.1.0",
-                "inherits": "^2.0.1",
-                "is-binary-path": "^1.0.0",
-                "is-glob": "^4.0.0",
-                "normalize-path": "^2.1.1",
-                "path-is-absolute": "^1.0.0",
-                "readdirp": "^2.0.0",
-                "upath": "^1.0.0"
+                "anymatch": "2.0.0",
+                "async-each": "1.0.1",
+                "braces": "2.3.2",
+                "fsevents": "1.2.4",
+                "glob-parent": "3.1.0",
+                "inherits": "2.0.3",
+                "is-binary-path": "1.0.1",
+                "is-glob": "4.0.0",
+                "normalize-path": "2.1.1",
+                "path-is-absolute": "1.0.1",
+                "readdirp": "2.1.0",
+                "upath": "1.1.0"
             },
             "dependencies": {
                 "is-glob": {
@@ -893,7 +898,7 @@
                     "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "^2.1.1"
+                        "is-extglob": "2.1.1"
                     }
                 },
                 "normalize-path": {
@@ -902,7 +907,7 @@
                     "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
                     "dev": true,
                     "requires": {
-                        "remove-trailing-separator": "^1.0.1"
+                        "remove-trailing-separator": "1.1.0"
                     }
                 }
             }
@@ -931,8 +936,8 @@
             "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.0.1"
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.2"
             }
         },
         "class-utils": {
@@ -941,10 +946,10 @@
             "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
             "dev": true,
             "requires": {
-                "arr-union": "^3.1.0",
-                "define-property": "^0.2.5",
-                "isobject": "^3.0.0",
-                "static-extend": "^0.1.1"
+                "arr-union": "3.1.0",
+                "define-property": "0.2.5",
+                "isobject": "3.0.1",
+                "static-extend": "0.1.2"
             },
             "dependencies": {
                 "define-property": {
@@ -953,7 +958,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 }
             }
@@ -964,7 +969,7 @@
             "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
             "dev": true,
             "requires": {
-                "restore-cursor": "^2.0.0"
+                "restore-cursor": "2.0.0"
             }
         },
         "cli-width": {
@@ -973,15 +978,50 @@
             "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
             "dev": true
         },
+        "clipboardy": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-1.2.3.tgz",
+            "integrity": "sha512-2WNImOvCRe6r63Gk9pShfkwXsVtKCroMAevIbiae021mS850UkWPbevxsBz3tnvjZIEGvlwaqCPsw+4ulzNgJA==",
+            "requires": {
+                "arch": "2.1.0",
+                "execa": "0.8.0"
+            },
+            "dependencies": {
+                "cross-spawn": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+                    "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+                    "requires": {
+                        "lru-cache": "4.1.3",
+                        "shebang-command": "1.2.0",
+                        "which": "1.3.1"
+                    }
+                },
+                "execa": {
+                    "version": "0.8.0",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
+                    "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
+                    "requires": {
+                        "cross-spawn": "5.1.0",
+                        "get-stream": "3.0.0",
+                        "is-stream": "1.1.0",
+                        "npm-run-path": "2.0.2",
+                        "p-finally": "1.0.0",
+                        "signal-exit": "3.0.2",
+                        "strip-eof": "1.0.0"
+                    }
+                }
+            }
+        },
         "cliui": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
             "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
             "dev": true,
             "requires": {
-                "string-width": "^2.1.1",
-                "strip-ansi": "^4.0.0",
-                "wrap-ansi": "^2.0.0"
+                "string-width": "2.1.1",
+                "strip-ansi": "4.0.0",
+                "wrap-ansi": "2.1.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -996,7 +1036,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^3.0.0"
+                        "ansi-regex": "3.0.0"
                     }
                 }
             }
@@ -1025,9 +1065,9 @@
             "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.1",
-                "process-nextick-args": "^2.0.0",
-                "readable-stream": "^2.3.5"
+                "inherits": "2.0.3",
+                "process-nextick-args": "2.0.0",
+                "readable-stream": "2.3.6"
             }
         },
         "co": {
@@ -1048,8 +1088,8 @@
             "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
             "dev": true,
             "requires": {
-                "map-visit": "^1.0.0",
-                "object-visit": "^1.0.0"
+                "map-visit": "1.0.0",
+                "object-visit": "1.0.1"
             }
         },
         "color-convert": {
@@ -1058,7 +1098,7 @@
             "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
             "dev": true,
             "requires": {
-                "color-name": "^1.1.1"
+                "color-name": "1.1.3"
             }
         },
         "color-name": {
@@ -1073,7 +1113,7 @@
             "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
             "dev": true,
             "requires": {
-                "delayed-stream": "~1.0.0"
+                "delayed-stream": "1.0.0"
             }
         },
         "commander": {
@@ -1106,10 +1146,10 @@
             "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
             "dev": true,
             "requires": {
-                "buffer-from": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.2.2",
-                "typedarray": "^0.0.6"
+                "buffer-from": "1.1.0",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6",
+                "typedarray": "0.0.6"
             }
         },
         "console-browserify": {
@@ -1118,7 +1158,7 @@
             "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
             "dev": true,
             "requires": {
-                "date-now": "^0.1.4"
+                "date-now": "0.1.4"
             }
         },
         "constants-browserify": {
@@ -1139,12 +1179,12 @@
             "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
             "dev": true,
             "requires": {
-                "aproba": "^1.1.1",
-                "fs-write-stream-atomic": "^1.0.8",
-                "iferr": "^0.1.5",
-                "mkdirp": "^0.5.1",
-                "rimraf": "^2.5.4",
-                "run-queue": "^1.0.0"
+                "aproba": "1.2.0",
+                "fs-write-stream-atomic": "1.0.10",
+                "iferr": "0.1.5",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2",
+                "run-queue": "1.0.3"
             }
         },
         "copy-descriptor": {
@@ -1152,15 +1192,6 @@
             "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
             "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
             "dev": true
-        },
-        "copy-paste": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/copy-paste/-/copy-paste-1.3.0.tgz",
-            "integrity": "sha1-p+bEocKP3t8rCB5yuX3y75X0ce0=",
-            "requires": {
-                "iconv-lite": "^0.4.8",
-                "sync-exec": "~0.6.x"
-            }
         },
         "core-util-is": {
             "version": "1.0.2",
@@ -1174,8 +1205,8 @@
             "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
             "dev": true,
             "requires": {
-                "bn.js": "^4.1.0",
-                "elliptic": "^6.0.0"
+                "bn.js": "4.11.8",
+                "elliptic": "6.4.0"
             }
         },
         "create-hash": {
@@ -1184,11 +1215,11 @@
             "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
             "dev": true,
             "requires": {
-                "cipher-base": "^1.0.1",
-                "inherits": "^2.0.1",
-                "md5.js": "^1.3.4",
-                "ripemd160": "^2.0.1",
-                "sha.js": "^2.4.0"
+                "cipher-base": "1.0.4",
+                "inherits": "2.0.3",
+                "md5.js": "1.3.4",
+                "ripemd160": "2.0.2",
+                "sha.js": "2.4.11"
             }
         },
         "create-hmac": {
@@ -1197,12 +1228,12 @@
             "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
             "dev": true,
             "requires": {
-                "cipher-base": "^1.0.3",
-                "create-hash": "^1.1.0",
-                "inherits": "^2.0.1",
-                "ripemd160": "^2.0.0",
-                "safe-buffer": "^5.0.1",
-                "sha.js": "^2.4.8"
+                "cipher-base": "1.0.4",
+                "create-hash": "1.2.0",
+                "inherits": "2.0.3",
+                "ripemd160": "2.0.2",
+                "safe-buffer": "5.1.2",
+                "sha.js": "2.4.11"
             }
         },
         "cross-spawn": {
@@ -1211,11 +1242,11 @@
             "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
             "dev": true,
             "requires": {
-                "nice-try": "^1.0.4",
-                "path-key": "^2.0.1",
-                "semver": "^5.5.0",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
+                "nice-try": "1.0.4",
+                "path-key": "2.0.1",
+                "semver": "5.5.0",
+                "shebang-command": "1.2.0",
+                "which": "1.3.1"
             }
         },
         "crypto-browserify": {
@@ -1224,17 +1255,17 @@
             "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
             "dev": true,
             "requires": {
-                "browserify-cipher": "^1.0.0",
-                "browserify-sign": "^4.0.0",
-                "create-ecdh": "^4.0.0",
-                "create-hash": "^1.1.0",
-                "create-hmac": "^1.1.0",
-                "diffie-hellman": "^5.0.0",
-                "inherits": "^2.0.1",
-                "pbkdf2": "^3.0.3",
-                "public-encrypt": "^4.0.0",
-                "randombytes": "^2.0.0",
-                "randomfill": "^1.0.3"
+                "browserify-cipher": "1.0.1",
+                "browserify-sign": "4.0.4",
+                "create-ecdh": "4.0.3",
+                "create-hash": "1.2.0",
+                "create-hmac": "1.1.7",
+                "diffie-hellman": "5.0.3",
+                "inherits": "2.0.3",
+                "pbkdf2": "3.0.16",
+                "public-encrypt": "4.0.2",
+                "randombytes": "2.0.6",
+                "randomfill": "1.0.4"
             }
         },
         "cyclist": {
@@ -1249,7 +1280,7 @@
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "dev": true,
             "requires": {
-                "assert-plus": "^1.0.0"
+                "assert-plus": "1.0.0"
             }
         },
         "date-fns": {
@@ -1290,7 +1321,7 @@
             "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
             "dev": true,
             "requires": {
-                "is-obj": "^1.0.0"
+                "is-obj": "1.0.1"
             }
         },
         "define-property": {
@@ -1299,8 +1330,8 @@
             "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
             "dev": true,
             "requires": {
-                "is-descriptor": "^1.0.2",
-                "isobject": "^3.0.1"
+                "is-descriptor": "1.0.2",
+                "isobject": "3.0.1"
             },
             "dependencies": {
                 "is-accessor-descriptor": {
@@ -1309,7 +1340,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -1318,7 +1349,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -1327,9 +1358,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
                     }
                 }
             }
@@ -1346,8 +1377,8 @@
             "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0"
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.1"
             }
         },
         "diff": {
@@ -1362,9 +1393,9 @@
             "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
             "dev": true,
             "requires": {
-                "bn.js": "^4.1.0",
-                "miller-rabin": "^4.0.0",
-                "randombytes": "^2.0.0"
+                "bn.js": "4.11.8",
+                "miller-rabin": "4.0.1",
+                "randombytes": "2.0.6"
             }
         },
         "domain-browser": {
@@ -1385,10 +1416,10 @@
             "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
             "dev": true,
             "requires": {
-                "end-of-stream": "^1.0.0",
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.0",
-                "stream-shift": "^1.0.0"
+                "end-of-stream": "1.4.1",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6",
+                "stream-shift": "1.0.0"
             }
         },
         "ecc-jsbn": {
@@ -1398,7 +1429,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "jsbn": "~0.1.0"
+                "jsbn": "0.1.1"
             }
         },
         "elliptic": {
@@ -1407,13 +1438,13 @@
             "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
             "dev": true,
             "requires": {
-                "bn.js": "^4.4.0",
-                "brorand": "^1.0.1",
-                "hash.js": "^1.0.0",
-                "hmac-drbg": "^1.0.0",
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0",
-                "minimalistic-crypto-utils": "^1.0.0"
+                "bn.js": "4.11.8",
+                "brorand": "1.1.0",
+                "hash.js": "1.1.3",
+                "hmac-drbg": "1.0.1",
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.1",
+                "minimalistic-crypto-utils": "1.0.1"
             }
         },
         "emojis-list": {
@@ -1428,7 +1459,7 @@
             "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
             "dev": true,
             "requires": {
-                "once": "^1.4.0"
+                "once": "1.4.0"
             }
         },
         "enhanced-resolve": {
@@ -1437,9 +1468,9 @@
             "integrity": "sha512-jox/62b2GofV1qTUQTMPEJSDIGycS43evqYzD/KVtEb9OCoki9cnacUPxCrZa7JfPzZSYOCZhu9O9luaMxAX8g==",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "memory-fs": "^0.4.0",
-                "tapable": "^1.0.0"
+                "graceful-fs": "4.1.11",
+                "memory-fs": "0.4.1",
+                "tapable": "1.0.0"
             }
         },
         "errno": {
@@ -1448,7 +1479,7 @@
             "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
             "dev": true,
             "requires": {
-                "prr": "~1.0.1"
+                "prr": "1.0.1"
             }
         },
         "escape-string-regexp": {
@@ -1463,8 +1494,8 @@
             "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
             "dev": true,
             "requires": {
-                "esrecurse": "^4.1.0",
-                "estraverse": "^4.1.1"
+                "esrecurse": "4.2.1",
+                "estraverse": "4.2.0"
             }
         },
         "esprima": {
@@ -1479,7 +1510,7 @@
             "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
             "dev": true,
             "requires": {
-                "estraverse": "^4.1.0"
+                "estraverse": "4.2.0"
             }
         },
         "estraverse": {
@@ -1500,13 +1531,13 @@
             "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
             "dev": true,
             "requires": {
-                "duplexer": "~0.1.1",
-                "from": "~0",
-                "map-stream": "~0.1.0",
+                "duplexer": "0.1.1",
+                "from": "0.1.7",
+                "map-stream": "0.1.0",
                 "pause-stream": "0.0.11",
-                "split": "0.3",
-                "stream-combiner": "~0.0.4",
-                "through": "~2.3.1"
+                "split": "0.3.3",
+                "stream-combiner": "0.0.4",
+                "through": "2.3.8"
             }
         },
         "events": {
@@ -1521,8 +1552,8 @@
             "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
             "dev": true,
             "requires": {
-                "md5.js": "^1.3.4",
-                "safe-buffer": "^5.1.1"
+                "md5.js": "1.3.4",
+                "safe-buffer": "5.1.2"
             }
         },
         "execa": {
@@ -1531,13 +1562,13 @@
             "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
             "dev": true,
             "requires": {
-                "cross-spawn": "^5.0.1",
-                "get-stream": "^3.0.0",
-                "is-stream": "^1.1.0",
-                "npm-run-path": "^2.0.0",
-                "p-finally": "^1.0.0",
-                "signal-exit": "^3.0.0",
-                "strip-eof": "^1.0.0"
+                "cross-spawn": "5.1.0",
+                "get-stream": "3.0.0",
+                "is-stream": "1.1.0",
+                "npm-run-path": "2.0.2",
+                "p-finally": "1.0.0",
+                "signal-exit": "3.0.2",
+                "strip-eof": "1.0.0"
             },
             "dependencies": {
                 "cross-spawn": {
@@ -1546,9 +1577,9 @@
                     "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
                     "dev": true,
                     "requires": {
-                        "lru-cache": "^4.0.1",
-                        "shebang-command": "^1.2.0",
-                        "which": "^1.2.9"
+                        "lru-cache": "4.1.3",
+                        "shebang-command": "1.2.0",
+                        "which": "1.3.1"
                     }
                 }
             }
@@ -1559,13 +1590,13 @@
             "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
             "dev": true,
             "requires": {
-                "debug": "^2.3.3",
-                "define-property": "^0.2.5",
-                "extend-shallow": "^2.0.1",
-                "posix-character-classes": "^0.1.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
+                "debug": "2.6.9",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "posix-character-classes": "0.1.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
             },
             "dependencies": {
                 "define-property": {
@@ -1574,7 +1605,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 },
                 "extend-shallow": {
@@ -1583,7 +1614,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 }
             }
@@ -1594,7 +1625,7 @@
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "dev": true,
             "requires": {
-                "fill-range": "^2.1.0"
+                "fill-range": "2.2.4"
             },
             "dependencies": {
                 "fill-range": {
@@ -1603,11 +1634,11 @@
                     "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
                     "dev": true,
                     "requires": {
-                        "is-number": "^2.1.0",
-                        "isobject": "^2.0.0",
-                        "randomatic": "^3.0.0",
-                        "repeat-element": "^1.1.2",
-                        "repeat-string": "^1.5.2"
+                        "is-number": "2.1.0",
+                        "isobject": "2.1.0",
+                        "randomatic": "3.0.0",
+                        "repeat-element": "1.1.2",
+                        "repeat-string": "1.6.1"
                     }
                 },
                 "is-number": {
@@ -1616,7 +1647,7 @@
                     "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.0.2"
+                        "kind-of": "3.2.2"
                     }
                 },
                 "isobject": {
@@ -1634,7 +1665,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -1651,8 +1682,8 @@
             "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
             "dev": true,
             "requires": {
-                "assign-symbols": "^1.0.0",
-                "is-extendable": "^1.0.1"
+                "assign-symbols": "1.0.0",
+                "is-extendable": "1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -1661,7 +1692,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "^2.0.4"
+                        "is-plain-object": "2.0.4"
                     }
                 }
             }
@@ -1672,9 +1703,9 @@
             "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
             "dev": true,
             "requires": {
-                "chardet": "^0.4.0",
-                "iconv-lite": "^0.4.17",
-                "tmp": "^0.0.33"
+                "chardet": "0.4.2",
+                "iconv-lite": "0.4.23",
+                "tmp": "0.0.33"
             }
         },
         "extglob": {
@@ -1683,14 +1714,14 @@
             "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
             "dev": true,
             "requires": {
-                "array-unique": "^0.3.2",
-                "define-property": "^1.0.0",
-                "expand-brackets": "^2.1.4",
-                "extend-shallow": "^2.0.1",
-                "fragment-cache": "^0.2.1",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
+                "array-unique": "0.3.2",
+                "define-property": "1.0.0",
+                "expand-brackets": "2.1.4",
+                "extend-shallow": "2.0.1",
+                "fragment-cache": "0.2.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
             },
             "dependencies": {
                 "define-property": {
@@ -1699,7 +1730,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^1.0.0"
+                        "is-descriptor": "1.0.2"
                     }
                 },
                 "extend-shallow": {
@@ -1708,7 +1739,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -1717,7 +1748,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -1726,7 +1757,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -1735,9 +1766,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
                     }
                 }
             }
@@ -1766,7 +1797,7 @@
             "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
             "dev": true,
             "requires": {
-                "pend": "~1.2.0"
+                "pend": "1.2.0"
             }
         },
         "figures": {
@@ -1775,7 +1806,7 @@
             "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
             "dev": true,
             "requires": {
-                "escape-string-regexp": "^1.0.5"
+                "escape-string-regexp": "1.0.5"
             }
         },
         "filename-regex": {
@@ -1790,10 +1821,10 @@
             "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
             "dev": true,
             "requires": {
-                "extend-shallow": "^2.0.1",
-                "is-number": "^3.0.0",
-                "repeat-string": "^1.6.1",
-                "to-regex-range": "^2.1.0"
+                "extend-shallow": "2.0.1",
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1",
+                "to-regex-range": "2.1.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -1802,7 +1833,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 }
             }
@@ -1813,9 +1844,9 @@
             "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
             "dev": true,
             "requires": {
-                "commondir": "^1.0.1",
-                "make-dir": "^1.0.0",
-                "pkg-dir": "^2.0.0"
+                "commondir": "1.0.1",
+                "make-dir": "1.3.0",
+                "pkg-dir": "2.0.0"
             }
         },
         "find-up": {
@@ -1824,7 +1855,7 @@
             "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
             "dev": true,
             "requires": {
-                "locate-path": "^2.0.0"
+                "locate-path": "2.0.0"
             }
         },
         "first-chunk-stream": {
@@ -1839,8 +1870,8 @@
             "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.4"
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6"
             }
         },
         "for-in": {
@@ -1855,7 +1886,7 @@
             "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
             "dev": true,
             "requires": {
-                "for-in": "^1.0.1"
+                "for-in": "1.0.2"
             }
         },
         "forever-agent": {
@@ -1870,9 +1901,9 @@
             "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
             "dev": true,
             "requires": {
-                "asynckit": "^0.4.0",
+                "asynckit": "0.4.0",
                 "combined-stream": "1.0.6",
-                "mime-types": "^2.1.12"
+                "mime-types": "2.1.18"
             }
         },
         "fragment-cache": {
@@ -1881,7 +1912,7 @@
             "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
             "dev": true,
             "requires": {
-                "map-cache": "^0.2.2"
+                "map-cache": "0.2.2"
             }
         },
         "from": {
@@ -1896,8 +1927,8 @@
             "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.0"
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6"
             }
         },
         "fs-write-stream-atomic": {
@@ -1906,10 +1937,10 @@
             "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "iferr": "^0.1.5",
-                "imurmurhash": "^0.1.4",
-                "readable-stream": "1 || 2"
+                "graceful-fs": "4.1.11",
+                "iferr": "0.1.5",
+                "imurmurhash": "0.1.4",
+                "readable-stream": "2.3.6"
             }
         },
         "fs.realpath": {
@@ -1925,8 +1956,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "nan": "^2.9.2",
-                "node-pre-gyp": "^0.10.0"
+                "nan": "2.10.0",
+                "node-pre-gyp": "0.10.0"
             },
             "dependencies": {
                 "abbrev": {
@@ -1952,8 +1983,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "delegates": "^1.0.0",
-                        "readable-stream": "^2.0.6"
+                        "delegates": "1.0.0",
+                        "readable-stream": "2.3.6"
                     }
                 },
                 "balanced-match": {
@@ -1966,7 +1997,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "balanced-match": "^1.0.0",
+                        "balanced-match": "1.0.0",
                         "concat-map": "0.0.1"
                     }
                 },
@@ -2030,7 +2061,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "minipass": "^2.2.1"
+                        "minipass": "2.2.4"
                     }
                 },
                 "fs.realpath": {
@@ -2045,14 +2076,14 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "aproba": "^1.0.3",
-                        "console-control-strings": "^1.0.0",
-                        "has-unicode": "^2.0.0",
-                        "object-assign": "^4.1.0",
-                        "signal-exit": "^3.0.0",
-                        "string-width": "^1.0.1",
-                        "strip-ansi": "^3.0.1",
-                        "wide-align": "^1.1.0"
+                        "aproba": "1.2.0",
+                        "console-control-strings": "1.1.0",
+                        "has-unicode": "2.0.1",
+                        "object-assign": "4.1.1",
+                        "signal-exit": "3.0.2",
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1",
+                        "wide-align": "1.1.2"
                     }
                 },
                 "glob": {
@@ -2061,12 +2092,12 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
                     }
                 },
                 "has-unicode": {
@@ -2081,7 +2112,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "safer-buffer": "^2.1.0"
+                        "safer-buffer": "2.1.2"
                     }
                 },
                 "ignore-walk": {
@@ -2090,7 +2121,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "minimatch": "^3.0.4"
+                        "minimatch": "3.0.4"
                     }
                 },
                 "inflight": {
@@ -2099,8 +2130,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "once": "^1.3.0",
-                        "wrappy": "1"
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
                     }
                 },
                 "inherits": {
@@ -2119,7 +2150,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "number-is-nan": "^1.0.0"
+                        "number-is-nan": "1.0.1"
                     }
                 },
                 "isarray": {
@@ -2133,7 +2164,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "^1.1.7"
+                        "brace-expansion": "1.1.11"
                     }
                 },
                 "minimist": {
@@ -2146,8 +2177,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "^5.1.1",
-                        "yallist": "^3.0.0"
+                        "safe-buffer": "5.1.1",
+                        "yallist": "3.0.2"
                     }
                 },
                 "minizlib": {
@@ -2156,7 +2187,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "minipass": "^2.2.1"
+                        "minipass": "2.2.4"
                     }
                 },
                 "mkdirp": {
@@ -2179,9 +2210,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "debug": "^2.1.2",
-                        "iconv-lite": "^0.4.4",
-                        "sax": "^1.2.4"
+                        "debug": "2.6.9",
+                        "iconv-lite": "0.4.21",
+                        "sax": "1.2.4"
                     }
                 },
                 "node-pre-gyp": {
@@ -2190,16 +2221,16 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "detect-libc": "^1.0.2",
-                        "mkdirp": "^0.5.1",
-                        "needle": "^2.2.0",
-                        "nopt": "^4.0.1",
-                        "npm-packlist": "^1.1.6",
-                        "npmlog": "^4.0.2",
-                        "rc": "^1.1.7",
-                        "rimraf": "^2.6.1",
-                        "semver": "^5.3.0",
-                        "tar": "^4"
+                        "detect-libc": "1.0.3",
+                        "mkdirp": "0.5.1",
+                        "needle": "2.2.0",
+                        "nopt": "4.0.1",
+                        "npm-packlist": "1.1.10",
+                        "npmlog": "4.1.2",
+                        "rc": "1.2.7",
+                        "rimraf": "2.6.2",
+                        "semver": "5.5.0",
+                        "tar": "4.4.1"
                     }
                 },
                 "nopt": {
@@ -2208,8 +2239,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "abbrev": "1",
-                        "osenv": "^0.1.4"
+                        "abbrev": "1.1.1",
+                        "osenv": "0.1.5"
                     }
                 },
                 "npm-bundled": {
@@ -2224,8 +2255,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "ignore-walk": "^3.0.1",
-                        "npm-bundled": "^1.0.1"
+                        "ignore-walk": "3.0.1",
+                        "npm-bundled": "1.0.3"
                     }
                 },
                 "npmlog": {
@@ -2234,10 +2265,10 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "are-we-there-yet": "~1.1.2",
-                        "console-control-strings": "~1.1.0",
-                        "gauge": "~2.7.3",
-                        "set-blocking": "~2.0.0"
+                        "are-we-there-yet": "1.1.4",
+                        "console-control-strings": "1.1.0",
+                        "gauge": "2.7.4",
+                        "set-blocking": "2.0.0"
                     }
                 },
                 "number-is-nan": {
@@ -2256,7 +2287,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "wrappy": "1"
+                        "wrappy": "1.0.2"
                     }
                 },
                 "os-homedir": {
@@ -2277,8 +2308,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "os-homedir": "^1.0.0",
-                        "os-tmpdir": "^1.0.0"
+                        "os-homedir": "1.0.2",
+                        "os-tmpdir": "1.0.2"
                     }
                 },
                 "path-is-absolute": {
@@ -2299,10 +2330,10 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "deep-extend": "^0.5.1",
-                        "ini": "~1.3.0",
-                        "minimist": "^1.2.0",
-                        "strip-json-comments": "~2.0.1"
+                        "deep-extend": "0.5.1",
+                        "ini": "1.3.5",
+                        "minimist": "1.2.0",
+                        "strip-json-comments": "2.0.1"
                     },
                     "dependencies": {
                         "minimist": {
@@ -2319,13 +2350,13 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "rimraf": {
@@ -2334,7 +2365,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "glob": "^7.0.5"
+                        "glob": "7.1.2"
                     }
                 },
                 "safe-buffer": {
@@ -2377,9 +2408,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
                     }
                 },
                 "string_decoder": {
@@ -2388,7 +2419,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.1"
                     }
                 },
                 "strip-ansi": {
@@ -2396,7 +2427,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^2.0.0"
+                        "ansi-regex": "2.1.1"
                     }
                 },
                 "strip-json-comments": {
@@ -2411,13 +2442,13 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "chownr": "^1.0.1",
-                        "fs-minipass": "^1.2.5",
-                        "minipass": "^2.2.4",
-                        "minizlib": "^1.1.0",
-                        "mkdirp": "^0.5.0",
-                        "safe-buffer": "^5.1.1",
-                        "yallist": "^3.0.2"
+                        "chownr": "1.0.1",
+                        "fs-minipass": "1.2.5",
+                        "minipass": "2.2.4",
+                        "minizlib": "1.1.0",
+                        "mkdirp": "0.5.1",
+                        "safe-buffer": "5.1.1",
+                        "yallist": "3.0.2"
                     }
                 },
                 "util-deprecate": {
@@ -2432,7 +2463,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "string-width": "^1.0.2"
+                        "string-width": "1.0.2"
                     }
                 },
                 "wrappy": {
@@ -2453,10 +2484,10 @@
             "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "inherits": "~2.0.0",
-                "mkdirp": ">=0.5 0",
-                "rimraf": "2"
+                "graceful-fs": "4.1.11",
+                "inherits": "2.0.3",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2"
             }
         },
         "get-caller-file": {
@@ -2468,8 +2499,7 @@
         "get-stream": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-            "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-            "dev": true
+            "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
         },
         "get-value": {
             "version": "2.0.6",
@@ -2483,7 +2513,7 @@
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "dev": true,
             "requires": {
-                "assert-plus": "^1.0.0"
+                "assert-plus": "1.0.0"
             }
         },
         "glob": {
@@ -2492,12 +2522,12 @@
             "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
             "dev": true,
             "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
             }
         },
         "glob-base": {
@@ -2506,8 +2536,8 @@
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
             "dev": true,
             "requires": {
-                "glob-parent": "^2.0.0",
-                "is-glob": "^2.0.0"
+                "glob-parent": "2.0.0",
+                "is-glob": "2.0.1"
             },
             "dependencies": {
                 "glob-parent": {
@@ -2516,7 +2546,7 @@
                     "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
                     "dev": true,
                     "requires": {
-                        "is-glob": "^2.0.0"
+                        "is-glob": "2.0.1"
                     }
                 },
                 "is-extglob": {
@@ -2531,7 +2561,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "^1.0.0"
+                        "is-extglob": "1.0.0"
                     }
                 }
             }
@@ -2542,8 +2572,8 @@
             "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
             "dev": true,
             "requires": {
-                "is-glob": "^3.1.0",
-                "path-dirname": "^1.0.0"
+                "is-glob": "3.1.0",
+                "path-dirname": "1.0.2"
             }
         },
         "glob-stream": {
@@ -2552,14 +2582,14 @@
             "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
             "dev": true,
             "requires": {
-                "extend": "^3.0.0",
-                "glob": "^5.0.3",
-                "glob-parent": "^3.0.0",
-                "micromatch": "^2.3.7",
-                "ordered-read-streams": "^0.3.0",
-                "through2": "^0.6.0",
-                "to-absolute-glob": "^0.1.1",
-                "unique-stream": "^2.0.2"
+                "extend": "3.0.1",
+                "glob": "5.0.15",
+                "glob-parent": "3.1.0",
+                "micromatch": "2.3.11",
+                "ordered-read-streams": "0.3.0",
+                "through2": "0.6.5",
+                "to-absolute-glob": "0.1.1",
+                "unique-stream": "2.2.1"
             },
             "dependencies": {
                 "arr-diff": {
@@ -2568,7 +2598,7 @@
                     "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "^1.0.1"
+                        "arr-flatten": "1.1.0"
                     }
                 },
                 "array-unique": {
@@ -2583,9 +2613,9 @@
                     "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
                     "dev": true,
                     "requires": {
-                        "expand-range": "^1.8.1",
-                        "preserve": "^0.2.0",
-                        "repeat-element": "^1.1.2"
+                        "expand-range": "1.8.2",
+                        "preserve": "0.2.0",
+                        "repeat-element": "1.1.2"
                     }
                 },
                 "expand-brackets": {
@@ -2594,7 +2624,7 @@
                     "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
                     "dev": true,
                     "requires": {
-                        "is-posix-bracket": "^0.1.0"
+                        "is-posix-bracket": "0.1.1"
                     }
                 },
                 "extglob": {
@@ -2603,7 +2633,7 @@
                     "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "^1.0.0"
+                        "is-extglob": "1.0.0"
                     }
                 },
                 "glob": {
@@ -2612,11 +2642,11 @@
                     "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                     "dev": true,
                     "requires": {
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "2 || 3",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
                     }
                 },
                 "is-extglob": {
@@ -2631,7 +2661,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "^1.0.0"
+                        "is-extglob": "1.0.0"
                     }
                 },
                 "isarray": {
@@ -2646,7 +2676,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 },
                 "micromatch": {
@@ -2655,19 +2685,19 @@
                     "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "^2.0.0",
-                        "array-unique": "^0.2.1",
-                        "braces": "^1.8.2",
-                        "expand-brackets": "^0.1.4",
-                        "extglob": "^0.3.1",
-                        "filename-regex": "^2.0.0",
-                        "is-extglob": "^1.0.0",
-                        "is-glob": "^2.0.1",
-                        "kind-of": "^3.0.2",
-                        "normalize-path": "^2.0.1",
-                        "object.omit": "^2.0.0",
-                        "parse-glob": "^3.0.4",
-                        "regex-cache": "^0.4.2"
+                        "arr-diff": "2.0.0",
+                        "array-unique": "0.2.1",
+                        "braces": "1.8.5",
+                        "expand-brackets": "0.1.5",
+                        "extglob": "0.3.2",
+                        "filename-regex": "2.0.1",
+                        "is-extglob": "1.0.0",
+                        "is-glob": "2.0.1",
+                        "kind-of": "3.2.2",
+                        "normalize-path": "2.1.1",
+                        "object.omit": "2.0.1",
+                        "parse-glob": "3.0.4",
+                        "regex-cache": "0.4.4"
                     }
                 },
                 "normalize-path": {
@@ -2676,7 +2706,7 @@
                     "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
                     "dev": true,
                     "requires": {
-                        "remove-trailing-separator": "^1.0.1"
+                        "remove-trailing-separator": "1.1.0"
                     }
                 },
                 "readable-stream": {
@@ -2685,10 +2715,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
                         "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
+                        "string_decoder": "0.10.31"
                     }
                 },
                 "string_decoder": {
@@ -2703,8 +2733,8 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                        "xtend": ">=4.0.0 <4.1.0-0"
+                        "readable-stream": "1.0.34",
+                        "xtend": "4.0.1"
                     }
                 }
             }
@@ -2733,9 +2763,9 @@
             "integrity": "sha1-AMOQuSigeZslGsz2MaoJ4BzGKZw=",
             "dev": true,
             "requires": {
-                "deep-assign": "^1.0.0",
-                "stat-mode": "^0.2.0",
-                "through2": "^2.0.0"
+                "deep-assign": "1.0.0",
+                "stat-mode": "0.2.2",
+                "through2": "2.0.3"
             }
         },
         "gulp-filter": {
@@ -2744,9 +2774,9 @@
             "integrity": "sha1-oF4Rr/sHz33PQafeHLe2OsN4PnM=",
             "dev": true,
             "requires": {
-                "multimatch": "^2.0.0",
-                "plugin-error": "^0.1.2",
-                "streamfilter": "^1.0.5"
+                "multimatch": "2.1.0",
+                "plugin-error": "0.1.2",
+                "streamfilter": "1.0.7"
             }
         },
         "gulp-gunzip": {
@@ -2755,8 +2785,8 @@
             "integrity": "sha1-FbdBFF6Dqcb1CIYkG1fMWHHxUak=",
             "dev": true,
             "requires": {
-                "through2": "~0.6.5",
-                "vinyl": "~0.4.6"
+                "through2": "0.6.5",
+                "vinyl": "0.4.6"
             },
             "dependencies": {
                 "isarray": {
@@ -2771,10 +2801,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
                         "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
+                        "string_decoder": "0.10.31"
                     }
                 },
                 "string_decoder": {
@@ -2789,8 +2819,8 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                        "xtend": ">=4.0.0 <4.1.0-0"
+                        "readable-stream": "1.0.34",
+                        "xtend": "4.0.1"
                     }
                 }
             }
@@ -2801,11 +2831,11 @@
             "integrity": "sha512-/9vtSk9eI9DEWCqzGieglPqmx0WUQ9pwPHyHFpKmfxqdgqGJC2l0vFMdYs54hLdDsMDEZFLDL2J4ikjc4hQ5HQ==",
             "dev": true,
             "requires": {
-                "event-stream": "^3.3.4",
-                "node.extend": "^1.1.2",
-                "request": "^2.79.0",
-                "through2": "^2.0.3",
-                "vinyl": "^2.0.1"
+                "event-stream": "3.3.4",
+                "node.extend": "1.1.6",
+                "request": "2.87.0",
+                "through2": "2.0.3",
+                "vinyl": "2.1.0"
             },
             "dependencies": {
                 "clone": {
@@ -2826,12 +2856,12 @@
                     "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
                     "dev": true,
                     "requires": {
-                        "clone": "^2.1.1",
-                        "clone-buffer": "^1.0.0",
-                        "clone-stats": "^1.0.0",
-                        "cloneable-readable": "^1.0.0",
-                        "remove-trailing-separator": "^1.0.1",
-                        "replace-ext": "^1.0.0"
+                        "clone": "2.1.1",
+                        "clone-buffer": "1.0.0",
+                        "clone-stats": "1.0.0",
+                        "cloneable-readable": "1.1.2",
+                        "remove-trailing-separator": "1.1.0",
+                        "replace-ext": "1.0.0"
                     }
                 }
             }
@@ -2842,11 +2872,11 @@
             "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
             "dev": true,
             "requires": {
-                "convert-source-map": "^1.1.1",
-                "graceful-fs": "^4.1.2",
-                "strip-bom": "^2.0.0",
-                "through2": "^2.0.0",
-                "vinyl": "^1.0.0"
+                "convert-source-map": "1.5.1",
+                "graceful-fs": "4.1.11",
+                "strip-bom": "2.0.0",
+                "through2": "2.0.3",
+                "vinyl": "1.2.0"
             },
             "dependencies": {
                 "clone": {
@@ -2867,8 +2897,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "^1.0.0",
-                        "clone-stats": "^0.0.1",
+                        "clone": "1.0.4",
+                        "clone-stats": "0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -2880,10 +2910,10 @@
             "integrity": "sha1-wWUyBzLRks5W/ZQnH/oSMjS/KuA=",
             "dev": true,
             "requires": {
-                "event-stream": "^3.3.1",
-                "mkdirp": "^0.5.1",
-                "queue": "^3.1.0",
-                "vinyl-fs": "^2.4.3"
+                "event-stream": "3.3.4",
+                "mkdirp": "0.5.1",
+                "queue": "3.1.0",
+                "vinyl-fs": "2.4.4"
             }
         },
         "gulp-untar": {
@@ -2892,11 +2922,11 @@
             "integrity": "sha512-0QfbCH2a1k2qkTLWPqTX+QO4qNsHn3kC546YhAP3/n0h+nvtyGITDuDrYBMDZeW4WnFijmkOvBWa5HshTic1tw==",
             "dev": true,
             "requires": {
-                "event-stream": "~3.3.4",
-                "streamifier": "~0.1.1",
-                "tar": "^2.2.1",
-                "through2": "~2.0.3",
-                "vinyl": "^1.2.0"
+                "event-stream": "3.3.4",
+                "streamifier": "0.1.1",
+                "tar": "2.2.1",
+                "through2": "2.0.3",
+                "vinyl": "1.2.0"
             },
             "dependencies": {
                 "clone": {
@@ -2917,8 +2947,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "^1.0.0",
-                        "clone-stats": "^0.0.1",
+                        "clone": "1.0.4",
+                        "clone-stats": "0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -2930,13 +2960,13 @@
             "integrity": "sha1-JOQGhdwFtxSZlSRQmeBZAmO+ja0=",
             "dev": true,
             "requires": {
-                "event-stream": "^3.3.1",
-                "queue": "^4.2.1",
-                "through2": "^2.0.3",
-                "vinyl": "^2.0.2",
-                "vinyl-fs": "^2.0.0",
-                "yauzl": "^2.2.1",
-                "yazl": "^2.2.1"
+                "event-stream": "3.3.4",
+                "queue": "4.4.2",
+                "through2": "2.0.3",
+                "vinyl": "2.1.0",
+                "vinyl-fs": "2.4.4",
+                "yauzl": "2.9.1",
+                "yazl": "2.4.3"
             },
             "dependencies": {
                 "clone": {
@@ -2957,7 +2987,7 @@
                     "integrity": "sha512-fSMRXbwhMwipcDZ08enW2vl+YDmAmhcNcr43sCJL8DIg+CFOsoRLG23ctxA+fwNk1w55SePSiS7oqQQSgQoVJQ==",
                     "dev": true,
                     "requires": {
-                        "inherits": "~2.0.0"
+                        "inherits": "2.0.3"
                     }
                 },
                 "vinyl": {
@@ -2966,12 +2996,12 @@
                     "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
                     "dev": true,
                     "requires": {
-                        "clone": "^2.1.1",
-                        "clone-buffer": "^1.0.0",
-                        "clone-stats": "^1.0.0",
-                        "cloneable-readable": "^1.0.0",
-                        "remove-trailing-separator": "^1.0.1",
-                        "replace-ext": "^1.0.0"
+                        "clone": "2.1.1",
+                        "clone-buffer": "1.0.0",
+                        "clone-stats": "1.0.0",
+                        "cloneable-readable": "1.1.2",
+                        "remove-trailing-separator": "1.1.0",
+                        "replace-ext": "1.0.0"
                     }
                 }
             }
@@ -2988,8 +3018,8 @@
             "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
             "dev": true,
             "requires": {
-                "ajv": "^5.1.0",
-                "har-schema": "^2.0.0"
+                "ajv": "5.5.2",
+                "har-schema": "2.0.0"
             },
             "dependencies": {
                 "ajv": {
@@ -2998,10 +3028,10 @@
                     "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
                     "dev": true,
                     "requires": {
-                        "co": "^4.6.0",
-                        "fast-deep-equal": "^1.0.0",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "json-schema-traverse": "^0.3.0"
+                        "co": "4.6.0",
+                        "fast-deep-equal": "1.1.0",
+                        "fast-json-stable-stringify": "2.0.0",
+                        "json-schema-traverse": "0.3.1"
                     }
                 },
                 "fast-deep-equal": {
@@ -3018,7 +3048,7 @@
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "dev": true,
             "requires": {
-                "ansi-regex": "^2.0.0"
+                "ansi-regex": "2.1.1"
             }
         },
         "has-flag": {
@@ -3033,9 +3063,9 @@
             "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
             "dev": true,
             "requires": {
-                "get-value": "^2.0.6",
-                "has-values": "^1.0.0",
-                "isobject": "^3.0.0"
+                "get-value": "2.0.6",
+                "has-values": "1.0.0",
+                "isobject": "3.0.1"
             }
         },
         "has-values": {
@@ -3044,8 +3074,8 @@
             "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
             "dev": true,
             "requires": {
-                "is-number": "^3.0.0",
-                "kind-of": "^4.0.0"
+                "is-number": "3.0.0",
+                "kind-of": "4.0.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -3054,7 +3084,7 @@
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -3065,8 +3095,8 @@
             "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.0.1"
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.2"
             }
         },
         "hash.js": {
@@ -3075,8 +3105,8 @@
             "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.3",
-                "minimalistic-assert": "^1.0.0"
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.1"
             }
         },
         "he": {
@@ -3091,9 +3121,9 @@
             "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
             "dev": true,
             "requires": {
-                "hash.js": "^1.0.3",
-                "minimalistic-assert": "^1.0.0",
-                "minimalistic-crypto-utils": "^1.0.1"
+                "hash.js": "1.1.3",
+                "minimalistic-assert": "1.0.1",
+                "minimalistic-crypto-utils": "1.0.1"
             }
         },
         "http-signature": {
@@ -3102,9 +3132,9 @@
             "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
             "dev": true,
             "requires": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
+                "assert-plus": "1.0.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.14.1"
             }
         },
         "https-browserify": {
@@ -3119,9 +3149,9 @@
             "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
             "dev": true,
             "requires": {
-                "is-ci": "^1.0.10",
-                "normalize-path": "^1.0.0",
-                "strip-indent": "^2.0.0"
+                "is-ci": "1.1.0",
+                "normalize-path": "1.0.0",
+                "strip-indent": "2.0.0"
             }
         },
         "iconv-lite": {
@@ -3129,7 +3159,7 @@
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
             "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
             "requires": {
-                "safer-buffer": ">= 2.1.2 < 3"
+                "safer-buffer": "2.1.2"
             }
         },
         "ieee754": {
@@ -3150,8 +3180,8 @@
             "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
             "dev": true,
             "requires": {
-                "pkg-dir": "^2.0.0",
-                "resolve-cwd": "^2.0.0"
+                "pkg-dir": "2.0.0",
+                "resolve-cwd": "2.0.0"
             }
         },
         "imurmurhash": {
@@ -3172,8 +3202,8 @@
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "dev": true,
             "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
             }
         },
         "inherits": {
@@ -3188,19 +3218,19 @@
             "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
             "dev": true,
             "requires": {
-                "ansi-escapes": "^3.0.0",
-                "chalk": "^2.0.0",
-                "cli-cursor": "^2.1.0",
-                "cli-width": "^2.0.0",
-                "external-editor": "^2.1.0",
-                "figures": "^2.0.0",
-                "lodash": "^4.3.0",
+                "ansi-escapes": "3.1.0",
+                "chalk": "2.4.1",
+                "cli-cursor": "2.1.0",
+                "cli-width": "2.2.0",
+                "external-editor": "2.2.0",
+                "figures": "2.0.0",
+                "lodash": "4.17.10",
                 "mute-stream": "0.0.7",
-                "run-async": "^2.2.0",
-                "rxjs": "^5.5.2",
-                "string-width": "^2.1.0",
-                "strip-ansi": "^4.0.0",
-                "through": "^2.3.6"
+                "run-async": "2.3.0",
+                "rxjs": "5.5.11",
+                "string-width": "2.1.1",
+                "strip-ansi": "4.0.0",
+                "through": "2.3.8"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -3215,7 +3245,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^3.0.0"
+                        "ansi-regex": "3.0.0"
                     }
                 }
             }
@@ -3244,7 +3274,7 @@
             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
             "dev": true,
             "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -3253,7 +3283,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -3264,7 +3294,7 @@
             "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
             "dev": true,
             "requires": {
-                "binary-extensions": "^1.0.0"
+                "binary-extensions": "1.11.0"
             }
         },
         "is-buffer": {
@@ -3279,7 +3309,7 @@
             "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
             "dev": true,
             "requires": {
-                "ci-info": "^1.0.0"
+                "ci-info": "1.1.3"
             }
         },
         "is-data-descriptor": {
@@ -3288,7 +3318,7 @@
             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
             "dev": true,
             "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -3297,7 +3327,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -3308,9 +3338,9 @@
             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
             "dev": true,
             "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -3333,7 +3363,7 @@
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
             "dev": true,
             "requires": {
-                "is-primitive": "^2.0.0"
+                "is-primitive": "2.0.0"
             }
         },
         "is-extendable": {
@@ -3360,7 +3390,7 @@
             "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
             "dev": true,
             "requires": {
-                "is-extglob": "^2.1.0"
+                "is-extglob": "2.1.1"
             }
         },
         "is-number": {
@@ -3369,7 +3399,7 @@
             "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
             "dev": true,
             "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -3378,7 +3408,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -3395,7 +3425,7 @@
             "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
             "dev": true,
             "requires": {
-                "is-number": "^4.0.0"
+                "is-number": "4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -3412,7 +3442,7 @@
             "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
             "dev": true,
             "requires": {
-                "isobject": "^3.0.1"
+                "isobject": "3.0.1"
             }
         },
         "is-posix-bracket": {
@@ -3436,8 +3466,7 @@
         "is-stream": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-            "dev": true
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
         },
         "is-typedarray": {
             "version": "1.0.0",
@@ -3472,8 +3501,7 @@
         "isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-            "dev": true
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
         },
         "isobject": {
             "version": "3.0.1",
@@ -3499,8 +3527,8 @@
             "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
             "dev": true,
             "requires": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
+                "argparse": "1.0.10",
+                "esprima": "4.0.0"
             }
         },
         "jsbn": {
@@ -3534,7 +3562,7 @@
             "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
             "dev": true,
             "requires": {
-                "jsonify": "~0.0.0"
+                "jsonify": "0.0.0"
             }
         },
         "json-stringify-safe": {
@@ -3579,7 +3607,7 @@
             "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
             "dev": true,
             "requires": {
-                "readable-stream": "^2.0.5"
+                "readable-stream": "2.3.6"
             }
         },
         "lcid": {
@@ -3588,7 +3616,7 @@
             "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
             "dev": true,
             "requires": {
-                "invert-kv": "^1.0.0"
+                "invert-kv": "1.0.0"
             }
         },
         "leb": {
@@ -3609,9 +3637,9 @@
             "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
             "dev": true,
             "requires": {
-                "big.js": "^3.1.3",
-                "emojis-list": "^2.0.0",
-                "json5": "^0.5.0"
+                "big.js": "3.2.0",
+                "emojis-list": "2.1.0",
+                "json5": "0.5.1"
             }
         },
         "locate-path": {
@@ -3620,8 +3648,8 @@
             "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
             "dev": true,
             "requires": {
-                "p-locate": "^2.0.0",
-                "path-exists": "^3.0.0"
+                "p-locate": "2.0.0",
+                "path-exists": "3.0.0"
             }
         },
         "lodash": {
@@ -3656,10 +3684,9 @@
             "version": "4.1.3",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
             "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
-            "dev": true,
             "requires": {
-                "pseudomap": "^1.0.2",
-                "yallist": "^2.1.2"
+                "pseudomap": "1.0.2",
+                "yallist": "2.1.2"
             }
         },
         "make-dir": {
@@ -3668,7 +3695,7 @@
             "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
             "dev": true,
             "requires": {
-                "pify": "^3.0.0"
+                "pify": "3.0.0"
             }
         },
         "mamacro": {
@@ -3695,7 +3722,7 @@
             "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
             "dev": true,
             "requires": {
-                "object-visit": "^1.0.0"
+                "object-visit": "1.0.1"
             }
         },
         "math-random": {
@@ -3710,8 +3737,8 @@
             "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
             "dev": true,
             "requires": {
-                "hash-base": "^3.0.0",
-                "inherits": "^2.0.1"
+                "hash-base": "3.0.4",
+                "inherits": "2.0.3"
             }
         },
         "mem": {
@@ -3720,7 +3747,7 @@
             "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
             "dev": true,
             "requires": {
-                "mimic-fn": "^1.0.0"
+                "mimic-fn": "1.2.0"
             }
         },
         "memory-fs": {
@@ -3729,8 +3756,8 @@
             "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
             "dev": true,
             "requires": {
-                "errno": "^0.1.3",
-                "readable-stream": "^2.0.1"
+                "errno": "0.1.7",
+                "readable-stream": "2.3.6"
             }
         },
         "merge-stream": {
@@ -3739,7 +3766,7 @@
             "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
             "dev": true,
             "requires": {
-                "readable-stream": "^2.0.1"
+                "readable-stream": "2.3.6"
             }
         },
         "micromatch": {
@@ -3748,19 +3775,19 @@
             "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
             "dev": true,
             "requires": {
-                "arr-diff": "^4.0.0",
-                "array-unique": "^0.3.2",
-                "braces": "^2.3.1",
-                "define-property": "^2.0.2",
-                "extend-shallow": "^3.0.2",
-                "extglob": "^2.0.4",
-                "fragment-cache": "^0.2.1",
-                "kind-of": "^6.0.2",
-                "nanomatch": "^1.2.9",
-                "object.pick": "^1.3.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.2"
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "braces": "2.3.2",
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "extglob": "2.0.4",
+                "fragment-cache": "0.2.1",
+                "kind-of": "6.0.2",
+                "nanomatch": "1.2.9",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
             }
         },
         "miller-rabin": {
@@ -3769,8 +3796,8 @@
             "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
             "dev": true,
             "requires": {
-                "bn.js": "^4.0.0",
-                "brorand": "^1.0.1"
+                "bn.js": "4.11.8",
+                "brorand": "1.1.0"
             }
         },
         "mime-db": {
@@ -3785,7 +3812,7 @@
             "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
             "dev": true,
             "requires": {
-                "mime-db": "~1.33.0"
+                "mime-db": "1.33.0"
             }
         },
         "mimic-fn": {
@@ -3812,7 +3839,7 @@
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "dev": true,
             "requires": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "1.1.11"
             }
         },
         "minimist": {
@@ -3827,16 +3854,16 @@
             "integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
             "dev": true,
             "requires": {
-                "concat-stream": "^1.5.0",
-                "duplexify": "^3.4.2",
-                "end-of-stream": "^1.1.0",
-                "flush-write-stream": "^1.0.0",
-                "from2": "^2.1.0",
-                "parallel-transform": "^1.1.0",
-                "pump": "^2.0.1",
-                "pumpify": "^1.3.3",
-                "stream-each": "^1.1.0",
-                "through2": "^2.0.0"
+                "concat-stream": "1.6.2",
+                "duplexify": "3.6.0",
+                "end-of-stream": "1.4.1",
+                "flush-write-stream": "1.0.3",
+                "from2": "2.3.0",
+                "parallel-transform": "1.1.0",
+                "pump": "2.0.1",
+                "pumpify": "1.5.1",
+                "stream-each": "1.2.2",
+                "through2": "2.0.3"
             }
         },
         "mixin-deep": {
@@ -3845,8 +3872,8 @@
             "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
             "dev": true,
             "requires": {
-                "for-in": "^1.0.2",
-                "is-extendable": "^1.0.1"
+                "for-in": "1.0.2",
+                "is-extendable": "1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -3855,7 +3882,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "^2.0.4"
+                        "is-plain-object": "2.0.4"
                     }
                 }
             }
@@ -3920,7 +3947,7 @@
                     "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^2.0.0"
+                        "has-flag": "2.0.0"
                     }
                 }
             }
@@ -3931,12 +3958,12 @@
             "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
             "dev": true,
             "requires": {
-                "aproba": "^1.1.1",
-                "copy-concurrently": "^1.0.0",
-                "fs-write-stream-atomic": "^1.0.8",
-                "mkdirp": "^0.5.1",
-                "rimraf": "^2.5.4",
-                "run-queue": "^1.0.3"
+                "aproba": "1.2.0",
+                "copy-concurrently": "1.0.5",
+                "fs-write-stream-atomic": "1.0.10",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2",
+                "run-queue": "1.0.3"
             }
         },
         "ms": {
@@ -3951,10 +3978,10 @@
             "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
             "dev": true,
             "requires": {
-                "array-differ": "^1.0.0",
-                "array-union": "^1.0.1",
-                "arrify": "^1.0.0",
-                "minimatch": "^3.0.0"
+                "array-differ": "1.0.0",
+                "array-union": "1.0.2",
+                "arrify": "1.0.1",
+                "minimatch": "3.0.4"
             }
         },
         "mute-stream": {
@@ -3976,18 +4003,18 @@
             "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
             "dev": true,
             "requires": {
-                "arr-diff": "^4.0.0",
-                "array-unique": "^0.3.2",
-                "define-property": "^2.0.2",
-                "extend-shallow": "^3.0.2",
-                "fragment-cache": "^0.2.1",
-                "is-odd": "^2.0.0",
-                "is-windows": "^1.0.2",
-                "kind-of": "^6.0.2",
-                "object.pick": "^1.3.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "fragment-cache": "0.2.1",
+                "is-odd": "2.0.0",
+                "is-windows": "1.0.2",
+                "kind-of": "6.0.2",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
             }
         },
         "neo-async": {
@@ -4008,28 +4035,28 @@
             "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
             "dev": true,
             "requires": {
-                "assert": "^1.1.1",
-                "browserify-zlib": "^0.2.0",
-                "buffer": "^4.3.0",
-                "console-browserify": "^1.1.0",
-                "constants-browserify": "^1.0.0",
-                "crypto-browserify": "^3.11.0",
-                "domain-browser": "^1.1.1",
-                "events": "^1.0.0",
-                "https-browserify": "^1.0.0",
-                "os-browserify": "^0.3.0",
+                "assert": "1.4.1",
+                "browserify-zlib": "0.2.0",
+                "buffer": "4.9.1",
+                "console-browserify": "1.1.0",
+                "constants-browserify": "1.0.0",
+                "crypto-browserify": "3.12.0",
+                "domain-browser": "1.2.0",
+                "events": "1.1.1",
+                "https-browserify": "1.0.0",
+                "os-browserify": "0.3.0",
                 "path-browserify": "0.0.0",
-                "process": "^0.11.10",
-                "punycode": "^1.2.4",
-                "querystring-es3": "^0.2.0",
-                "readable-stream": "^2.3.3",
-                "stream-browserify": "^2.0.1",
-                "stream-http": "^2.7.2",
-                "string_decoder": "^1.0.0",
-                "timers-browserify": "^2.0.4",
+                "process": "0.11.10",
+                "punycode": "1.4.1",
+                "querystring-es3": "0.2.1",
+                "readable-stream": "2.3.6",
+                "stream-browserify": "2.0.1",
+                "stream-http": "2.8.3",
+                "string_decoder": "1.1.1",
+                "timers-browserify": "2.0.10",
                 "tty-browserify": "0.0.0",
-                "url": "^0.11.0",
-                "util": "^0.10.3",
+                "url": "0.11.0",
+                "util": "0.10.3",
                 "vm-browserify": "0.0.4"
             },
             "dependencies": {
@@ -4047,7 +4074,7 @@
             "integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
             "dev": true,
             "requires": {
-                "is": "^3.1.0"
+                "is": "3.2.1"
             }
         },
         "normalize-path": {
@@ -4060,9 +4087,8 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
             "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-            "dev": true,
             "requires": {
-                "path-key": "^2.0.0"
+                "path-key": "2.0.1"
             }
         },
         "number-is-nan": {
@@ -4089,9 +4115,9 @@
             "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
             "dev": true,
             "requires": {
-                "copy-descriptor": "^0.1.0",
-                "define-property": "^0.2.5",
-                "kind-of": "^3.0.3"
+                "copy-descriptor": "0.1.1",
+                "define-property": "0.2.5",
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "define-property": {
@@ -4100,7 +4126,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 },
                 "kind-of": {
@@ -4109,7 +4135,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -4120,7 +4146,7 @@
             "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
             "dev": true,
             "requires": {
-                "isobject": "^3.0.0"
+                "isobject": "3.0.1"
             }
         },
         "object.omit": {
@@ -4129,8 +4155,8 @@
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
             "dev": true,
             "requires": {
-                "for-own": "^0.1.4",
-                "is-extendable": "^0.1.1"
+                "for-own": "0.1.5",
+                "is-extendable": "0.1.1"
             }
         },
         "object.pick": {
@@ -4139,7 +4165,7 @@
             "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
             "dev": true,
             "requires": {
-                "isobject": "^3.0.1"
+                "isobject": "3.0.1"
             }
         },
         "once": {
@@ -4148,7 +4174,7 @@
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dev": true,
             "requires": {
-                "wrappy": "1"
+                "wrappy": "1.0.2"
             }
         },
         "onetime": {
@@ -4157,7 +4183,7 @@
             "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
             "dev": true,
             "requires": {
-                "mimic-fn": "^1.0.0"
+                "mimic-fn": "1.2.0"
             }
         },
         "ordered-read-streams": {
@@ -4166,8 +4192,8 @@
             "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
             "dev": true,
             "requires": {
-                "is-stream": "^1.0.1",
-                "readable-stream": "^2.0.1"
+                "is-stream": "1.1.0",
+                "readable-stream": "2.3.6"
             }
         },
         "os-browserify": {
@@ -4182,9 +4208,9 @@
             "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
             "dev": true,
             "requires": {
-                "execa": "^0.7.0",
-                "lcid": "^1.0.0",
-                "mem": "^1.1.0"
+                "execa": "0.7.0",
+                "lcid": "1.0.0",
+                "mem": "1.1.0"
             }
         },
         "os-tmpdir": {
@@ -4195,8 +4221,7 @@
         "p-finally": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-            "dev": true
+            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
         },
         "p-limit": {
             "version": "1.2.0",
@@ -4204,7 +4229,7 @@
             "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
             "dev": true,
             "requires": {
-                "p-try": "^1.0.0"
+                "p-try": "1.0.0"
             }
         },
         "p-locate": {
@@ -4213,7 +4238,7 @@
             "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
             "dev": true,
             "requires": {
-                "p-limit": "^1.1.0"
+                "p-limit": "1.2.0"
             }
         },
         "p-try": {
@@ -4234,9 +4259,9 @@
             "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
             "dev": true,
             "requires": {
-                "cyclist": "~0.2.2",
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.1.5"
+                "cyclist": "0.2.2",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6"
             }
         },
         "parse-asn1": {
@@ -4245,11 +4270,11 @@
             "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
             "dev": true,
             "requires": {
-                "asn1.js": "^4.0.0",
-                "browserify-aes": "^1.0.0",
-                "create-hash": "^1.1.0",
-                "evp_bytestokey": "^1.0.0",
-                "pbkdf2": "^3.0.3"
+                "asn1.js": "4.10.1",
+                "browserify-aes": "1.2.0",
+                "create-hash": "1.2.0",
+                "evp_bytestokey": "1.0.3",
+                "pbkdf2": "3.0.16"
             }
         },
         "parse-glob": {
@@ -4258,10 +4283,10 @@
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
             "dev": true,
             "requires": {
-                "glob-base": "^0.3.0",
-                "is-dotfile": "^1.0.0",
-                "is-extglob": "^1.0.0",
-                "is-glob": "^2.0.0"
+                "glob-base": "0.3.0",
+                "is-dotfile": "1.0.3",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1"
             },
             "dependencies": {
                 "is-extglob": {
@@ -4276,7 +4301,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "^1.0.0"
+                        "is-extglob": "1.0.0"
                     }
                 }
             }
@@ -4314,8 +4339,7 @@
         "path-key": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-            "dev": true
+            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
         },
         "path-parse": {
             "version": "1.0.5",
@@ -4329,7 +4353,7 @@
             "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
             "dev": true,
             "requires": {
-                "through": "~2.3"
+                "through": "2.3.8"
             }
         },
         "pbkdf2": {
@@ -4338,11 +4362,11 @@
             "integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
             "dev": true,
             "requires": {
-                "create-hash": "^1.1.2",
-                "create-hmac": "^1.1.4",
-                "ripemd160": "^2.0.1",
-                "safe-buffer": "^5.0.1",
-                "sha.js": "^2.4.8"
+                "create-hash": "1.2.0",
+                "create-hmac": "1.1.7",
+                "ripemd160": "2.0.2",
+                "safe-buffer": "5.1.2",
+                "sha.js": "2.4.11"
             }
         },
         "pend": {
@@ -4369,7 +4393,7 @@
             "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
             "dev": true,
             "requires": {
-                "find-up": "^2.1.0"
+                "find-up": "2.1.0"
             }
         },
         "plugin-error": {
@@ -4378,11 +4402,11 @@
             "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
             "dev": true,
             "requires": {
-                "ansi-cyan": "^0.1.1",
-                "ansi-red": "^0.1.1",
-                "arr-diff": "^1.0.1",
-                "arr-union": "^2.0.1",
-                "extend-shallow": "^1.1.2"
+                "ansi-cyan": "0.1.1",
+                "ansi-red": "0.1.1",
+                "arr-diff": "1.1.0",
+                "arr-union": "2.1.0",
+                "extend-shallow": "1.1.4"
             },
             "dependencies": {
                 "arr-diff": {
@@ -4391,8 +4415,8 @@
                     "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "^1.0.1",
-                        "array-slice": "^0.2.3"
+                        "arr-flatten": "1.1.0",
+                        "array-slice": "0.2.3"
                     }
                 },
                 "arr-union": {
@@ -4407,7 +4431,7 @@
                     "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^1.1.0"
+                        "kind-of": "1.1.0"
                     }
                 },
                 "kind-of": {
@@ -4457,8 +4481,7 @@
         "pseudomap": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-            "dev": true
+            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
         },
         "public-encrypt": {
             "version": "4.0.2",
@@ -4466,11 +4489,11 @@
             "integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
             "dev": true,
             "requires": {
-                "bn.js": "^4.1.0",
-                "browserify-rsa": "^4.0.0",
-                "create-hash": "^1.1.0",
-                "parse-asn1": "^5.0.0",
-                "randombytes": "^2.0.1"
+                "bn.js": "4.11.8",
+                "browserify-rsa": "4.0.1",
+                "create-hash": "1.2.0",
+                "parse-asn1": "5.1.1",
+                "randombytes": "2.0.6"
             }
         },
         "pump": {
@@ -4479,8 +4502,8 @@
             "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
             "dev": true,
             "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
+                "end-of-stream": "1.4.1",
+                "once": "1.4.0"
             }
         },
         "pumpify": {
@@ -4489,9 +4512,9 @@
             "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
             "dev": true,
             "requires": {
-                "duplexify": "^3.6.0",
-                "inherits": "^2.0.3",
-                "pump": "^2.0.0"
+                "duplexify": "3.6.0",
+                "inherits": "2.0.3",
+                "pump": "2.0.1"
             }
         },
         "punycode": {
@@ -4530,7 +4553,7 @@
             "integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
             "dev": true,
             "requires": {
-                "inherits": "~2.0.0"
+                "inherits": "2.0.3"
             }
         },
         "randomatic": {
@@ -4539,9 +4562,9 @@
             "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
             "dev": true,
             "requires": {
-                "is-number": "^4.0.0",
-                "kind-of": "^6.0.0",
-                "math-random": "^1.0.1"
+                "is-number": "4.0.0",
+                "kind-of": "6.0.2",
+                "math-random": "1.0.1"
             },
             "dependencies": {
                 "is-number": {
@@ -4558,7 +4581,7 @@
             "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
             "dev": true,
             "requires": {
-                "safe-buffer": "^5.1.0"
+                "safe-buffer": "5.1.2"
             }
         },
         "randomfill": {
@@ -4567,8 +4590,8 @@
             "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
             "dev": true,
             "requires": {
-                "randombytes": "^2.0.5",
-                "safe-buffer": "^5.1.0"
+                "randombytes": "2.0.6",
+                "safe-buffer": "5.1.2"
             }
         },
         "readable-stream": {
@@ -4577,13 +4600,13 @@
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
             "dev": true,
             "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.0",
+                "safe-buffer": "5.1.2",
+                "string_decoder": "1.1.1",
+                "util-deprecate": "1.0.2"
             }
         },
         "readdirp": {
@@ -4592,10 +4615,10 @@
             "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "minimatch": "^3.0.2",
-                "readable-stream": "^2.0.2",
-                "set-immediate-shim": "^1.0.1"
+                "graceful-fs": "4.1.11",
+                "minimatch": "3.0.4",
+                "readable-stream": "2.3.6",
+                "set-immediate-shim": "1.0.1"
             }
         },
         "regex-cache": {
@@ -4604,7 +4627,7 @@
             "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
             "dev": true,
             "requires": {
-                "is-equal-shallow": "^0.1.3"
+                "is-equal-shallow": "0.1.3"
             }
         },
         "regex-not": {
@@ -4613,8 +4636,8 @@
             "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
             "dev": true,
             "requires": {
-                "extend-shallow": "^3.0.2",
-                "safe-regex": "^1.1.0"
+                "extend-shallow": "3.0.2",
+                "safe-regex": "1.1.0"
             }
         },
         "remove-trailing-separator": {
@@ -4647,26 +4670,26 @@
             "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
             "dev": true,
             "requires": {
-                "aws-sign2": "~0.7.0",
-                "aws4": "^1.6.0",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.5",
-                "extend": "~3.0.1",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.3.1",
-                "har-validator": "~5.0.3",
-                "http-signature": "~1.2.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.17",
-                "oauth-sign": "~0.8.2",
-                "performance-now": "^2.1.0",
-                "qs": "~6.5.1",
-                "safe-buffer": "^5.1.1",
-                "tough-cookie": "~2.3.3",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.1.0"
+                "aws-sign2": "0.7.0",
+                "aws4": "1.7.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.6",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.3.2",
+                "har-validator": "5.0.3",
+                "http-signature": "1.2.0",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.18",
+                "oauth-sign": "0.8.2",
+                "performance-now": "2.1.0",
+                "qs": "6.5.2",
+                "safe-buffer": "5.1.2",
+                "tough-cookie": "2.3.4",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.2.1"
             }
         },
         "require-directory": {
@@ -4693,7 +4716,7 @@
             "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
             "dev": true,
             "requires": {
-                "path-parse": "^1.0.5"
+                "path-parse": "1.0.5"
             }
         },
         "resolve-cwd": {
@@ -4702,7 +4725,7 @@
             "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
             "dev": true,
             "requires": {
-                "resolve-from": "^3.0.0"
+                "resolve-from": "3.0.0"
             }
         },
         "resolve-from": {
@@ -4723,8 +4746,8 @@
             "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
             "dev": true,
             "requires": {
-                "onetime": "^2.0.0",
-                "signal-exit": "^3.0.2"
+                "onetime": "2.0.1",
+                "signal-exit": "3.0.2"
             }
         },
         "ret": {
@@ -4739,7 +4762,7 @@
             "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
             "dev": true,
             "requires": {
-                "glob": "^7.0.5"
+                "glob": "7.1.2"
             }
         },
         "ripemd160": {
@@ -4748,8 +4771,8 @@
             "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
             "dev": true,
             "requires": {
-                "hash-base": "^3.0.0",
-                "inherits": "^2.0.1"
+                "hash-base": "3.0.4",
+                "inherits": "2.0.3"
             }
         },
         "run-async": {
@@ -4758,7 +4781,7 @@
             "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
             "dev": true,
             "requires": {
-                "is-promise": "^2.1.0"
+                "is-promise": "2.1.0"
             }
         },
         "run-queue": {
@@ -4767,7 +4790,7 @@
             "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
             "dev": true,
             "requires": {
-                "aproba": "^1.1.1"
+                "aproba": "1.2.0"
             }
         },
         "rxjs": {
@@ -4791,7 +4814,7 @@
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
             "dev": true,
             "requires": {
-                "ret": "~0.1.10"
+                "ret": "0.1.15"
             }
         },
         "safer-buffer": {
@@ -4805,8 +4828,8 @@
             "integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
             "dev": true,
             "requires": {
-                "ajv": "^6.1.0",
-                "ajv-keywords": "^3.1.0"
+                "ajv": "6.5.0",
+                "ajv-keywords": "3.2.0"
             }
         },
         "semver": {
@@ -4839,10 +4862,10 @@
             "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
             "dev": true,
             "requires": {
-                "extend-shallow": "^2.0.1",
-                "is-extendable": "^0.1.1",
-                "is-plain-object": "^2.0.3",
-                "split-string": "^3.0.1"
+                "extend-shallow": "2.0.1",
+                "is-extendable": "0.1.1",
+                "is-plain-object": "2.0.4",
+                "split-string": "3.1.0"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -4851,7 +4874,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 }
             }
@@ -4868,30 +4891,27 @@
             "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.0.1"
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.2"
             }
         },
         "shebang-command": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-            "dev": true,
             "requires": {
-                "shebang-regex": "^1.0.0"
+                "shebang-regex": "1.0.0"
             }
         },
         "shebang-regex": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-            "dev": true
+            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
         },
         "signal-exit": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-            "dev": true
+            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
         },
         "snapdragon": {
             "version": "0.8.2",
@@ -4899,14 +4919,14 @@
             "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
             "dev": true,
             "requires": {
-                "base": "^0.11.1",
-                "debug": "^2.2.0",
-                "define-property": "^0.2.5",
-                "extend-shallow": "^2.0.1",
-                "map-cache": "^0.2.2",
-                "source-map": "^0.5.6",
-                "source-map-resolve": "^0.5.0",
-                "use": "^3.1.0"
+                "base": "0.11.2",
+                "debug": "2.6.9",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "map-cache": "0.2.2",
+                "source-map": "0.5.7",
+                "source-map-resolve": "0.5.2",
+                "use": "3.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -4915,7 +4935,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 },
                 "extend-shallow": {
@@ -4924,7 +4944,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 }
             }
@@ -4935,9 +4955,9 @@
             "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
             "dev": true,
             "requires": {
-                "define-property": "^1.0.0",
-                "isobject": "^3.0.0",
-                "snapdragon-util": "^3.0.1"
+                "define-property": "1.0.0",
+                "isobject": "3.0.1",
+                "snapdragon-util": "3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -4946,7 +4966,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^1.0.0"
+                        "is-descriptor": "1.0.2"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -4955,7 +4975,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -4964,7 +4984,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -4973,9 +4993,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
                     }
                 }
             }
@@ -4986,7 +5006,7 @@
             "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
             "dev": true,
             "requires": {
-                "kind-of": "^3.2.0"
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -4995,7 +5015,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -5018,11 +5038,11 @@
             "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
             "dev": true,
             "requires": {
-                "atob": "^2.1.1",
-                "decode-uri-component": "^0.2.0",
-                "resolve-url": "^0.2.1",
-                "source-map-url": "^0.4.0",
-                "urix": "^0.1.0"
+                "atob": "2.1.1",
+                "decode-uri-component": "0.2.0",
+                "resolve-url": "0.2.1",
+                "source-map-url": "0.4.0",
+                "urix": "0.1.0"
             }
         },
         "source-map-support": {
@@ -5031,8 +5051,8 @@
             "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
             "dev": true,
             "requires": {
-                "buffer-from": "^1.0.0",
-                "source-map": "^0.6.0"
+                "buffer-from": "1.1.0",
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "source-map": {
@@ -5055,7 +5075,7 @@
             "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
             "dev": true,
             "requires": {
-                "through": "2"
+                "through": "2.3.8"
             }
         },
         "split-string": {
@@ -5064,7 +5084,7 @@
             "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
             "dev": true,
             "requires": {
-                "extend-shallow": "^3.0.0"
+                "extend-shallow": "3.0.2"
             }
         },
         "sprintf-js": {
@@ -5079,14 +5099,14 @@
             "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
             "dev": true,
             "requires": {
-                "asn1": "~0.2.3",
-                "assert-plus": "^1.0.0",
-                "bcrypt-pbkdf": "^1.0.0",
-                "dashdash": "^1.12.0",
-                "ecc-jsbn": "~0.1.1",
-                "getpass": "^0.1.1",
-                "jsbn": "~0.1.0",
-                "tweetnacl": "~0.14.0"
+                "asn1": "0.2.3",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.1",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.1",
+                "getpass": "0.1.7",
+                "jsbn": "0.1.1",
+                "tweetnacl": "0.14.5"
             }
         },
         "ssri": {
@@ -5095,7 +5115,7 @@
             "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
             "dev": true,
             "requires": {
-                "safe-buffer": "^5.1.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "stat-mode": {
@@ -5110,8 +5130,8 @@
             "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
             "dev": true,
             "requires": {
-                "define-property": "^0.2.5",
-                "object-copy": "^0.1.0"
+                "define-property": "0.2.5",
+                "object-copy": "0.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -5120,7 +5140,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 }
             }
@@ -5131,8 +5151,8 @@
             "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
             "dev": true,
             "requires": {
-                "inherits": "~2.0.1",
-                "readable-stream": "^2.0.2"
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6"
             }
         },
         "stream-combiner": {
@@ -5141,7 +5161,7 @@
             "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
             "dev": true,
             "requires": {
-                "duplexer": "~0.1.1"
+                "duplexer": "0.1.1"
             }
         },
         "stream-each": {
@@ -5150,8 +5170,8 @@
             "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
             "dev": true,
             "requires": {
-                "end-of-stream": "^1.1.0",
-                "stream-shift": "^1.0.0"
+                "end-of-stream": "1.4.1",
+                "stream-shift": "1.0.0"
             }
         },
         "stream-http": {
@@ -5160,11 +5180,11 @@
             "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
             "dev": true,
             "requires": {
-                "builtin-status-codes": "^3.0.0",
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.3.6",
-                "to-arraybuffer": "^1.0.0",
-                "xtend": "^4.0.0"
+                "builtin-status-codes": "3.0.0",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6",
+                "to-arraybuffer": "1.0.1",
+                "xtend": "4.0.1"
             }
         },
         "stream-shift": {
@@ -5179,7 +5199,7 @@
             "integrity": "sha512-Gk6KZM+yNA1JpW0KzlZIhjo3EaBJDkYfXtYSbOwNIQ7Zd6006E6+sCFlW1NDvFG/vnXhKmw6TJJgiEQg/8lXfQ==",
             "dev": true,
             "requires": {
-                "readable-stream": "^2.0.2"
+                "readable-stream": "2.3.6"
             }
         },
         "streamifier": {
@@ -5194,8 +5214,8 @@
             "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
             "dev": true,
             "requires": {
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^4.0.0"
+                "is-fullwidth-code-point": "2.0.0",
+                "strip-ansi": "4.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -5210,7 +5230,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^3.0.0"
+                        "ansi-regex": "3.0.0"
                     }
                 }
             }
@@ -5221,7 +5241,7 @@
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "dev": true,
             "requires": {
-                "safe-buffer": "~5.1.0"
+                "safe-buffer": "5.1.2"
             }
         },
         "strip-ansi": {
@@ -5230,7 +5250,7 @@
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "requires": {
-                "ansi-regex": "^2.0.0"
+                "ansi-regex": "2.1.1"
             }
         },
         "strip-bom": {
@@ -5239,7 +5259,7 @@
             "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
             "dev": true,
             "requires": {
-                "is-utf8": "^0.2.0"
+                "is-utf8": "0.2.1"
             }
         },
         "strip-bom-stream": {
@@ -5248,15 +5268,14 @@
             "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
             "dev": true,
             "requires": {
-                "first-chunk-stream": "^1.0.0",
-                "strip-bom": "^2.0.0"
+                "first-chunk-stream": "1.0.0",
+                "strip-bom": "2.0.0"
             }
         },
         "strip-eof": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-            "dev": true
+            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
         },
         "strip-indent": {
             "version": "2.0.0",
@@ -5270,7 +5289,7 @@
             "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
             "dev": true,
             "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
             }
         },
         "symbol-observable": {
@@ -5278,12 +5297,6 @@
             "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
             "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
             "dev": true
-        },
-        "sync-exec": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/sync-exec/-/sync-exec-0.6.2.tgz",
-            "integrity": "sha1-cX0izFPwzh3vVZQ2LzqJouu5EQU=",
-            "optional": true
         },
         "tapable": {
             "version": "1.0.0",
@@ -5297,9 +5310,9 @@
             "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
             "dev": true,
             "requires": {
-                "block-stream": "*",
-                "fstream": "^1.0.2",
-                "inherits": "2"
+                "block-stream": "0.0.9",
+                "fstream": "1.0.11",
+                "inherits": "2.0.3"
             }
         },
         "through": {
@@ -5314,8 +5327,8 @@
             "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
             "dev": true,
             "requires": {
-                "readable-stream": "^2.1.5",
-                "xtend": "~4.0.1"
+                "readable-stream": "2.3.6",
+                "xtend": "4.0.1"
             }
         },
         "through2-filter": {
@@ -5324,8 +5337,8 @@
             "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
             "dev": true,
             "requires": {
-                "through2": "~2.0.0",
-                "xtend": "~4.0.0"
+                "through2": "2.0.3",
+                "xtend": "4.0.1"
             }
         },
         "timers-browserify": {
@@ -5334,7 +5347,7 @@
             "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
             "dev": true,
             "requires": {
-                "setimmediate": "^1.0.4"
+                "setimmediate": "1.0.5"
             }
         },
         "tmp": {
@@ -5342,7 +5355,7 @@
             "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
             "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
             "requires": {
-                "os-tmpdir": "~1.0.2"
+                "os-tmpdir": "1.0.2"
             }
         },
         "to-absolute-glob": {
@@ -5351,7 +5364,7 @@
             "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
             "dev": true,
             "requires": {
-                "extend-shallow": "^2.0.1"
+                "extend-shallow": "2.0.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -5360,7 +5373,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 }
             }
@@ -5377,7 +5390,7 @@
             "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
             "dev": true,
             "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -5386,7 +5399,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -5397,10 +5410,10 @@
             "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
             "dev": true,
             "requires": {
-                "define-property": "^2.0.2",
-                "extend-shallow": "^3.0.2",
-                "regex-not": "^1.0.2",
-                "safe-regex": "^1.1.0"
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "regex-not": "1.0.2",
+                "safe-regex": "1.1.0"
             }
         },
         "to-regex-range": {
@@ -5409,8 +5422,8 @@
             "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
             "dev": true,
             "requires": {
-                "is-number": "^3.0.0",
-                "repeat-string": "^1.6.1"
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1"
             }
         },
         "tough-cookie": {
@@ -5419,7 +5432,7 @@
             "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
             "dev": true,
             "requires": {
-                "punycode": "^1.4.1"
+                "punycode": "1.4.1"
             },
             "dependencies": {
                 "punycode": {
@@ -5436,11 +5449,11 @@
             "integrity": "sha512-ra304bebnyxd9nIJoKjQoeQLOENqrDG7vfppS+DkCnqOEv29GuiiWMvgebuCqFko0AkMFpoubRLeFM7YmlkL3w==",
             "dev": true,
             "requires": {
-                "chalk": "^2.3.0",
-                "enhanced-resolve": "^4.0.0",
-                "loader-utils": "^1.0.2",
-                "micromatch": "^3.1.4",
-                "semver": "^5.0.1"
+                "chalk": "2.4.1",
+                "enhanced-resolve": "4.0.0",
+                "loader-utils": "1.1.0",
+                "micromatch": "3.1.10",
+                "semver": "5.5.0"
             }
         },
         "tslib": {
@@ -5454,18 +5467,18 @@
             "integrity": "sha1-EeJrzLiK+gLdDZlWyuPUVAtfVMM=",
             "dev": true,
             "requires": {
-                "babel-code-frame": "^6.22.0",
-                "builtin-modules": "^1.1.1",
-                "chalk": "^2.3.0",
-                "commander": "^2.12.1",
-                "diff": "^3.2.0",
-                "glob": "^7.1.1",
-                "js-yaml": "^3.7.0",
-                "minimatch": "^3.0.4",
-                "resolve": "^1.3.2",
-                "semver": "^5.3.0",
-                "tslib": "^1.8.0",
-                "tsutils": "^2.12.1"
+                "babel-code-frame": "6.26.0",
+                "builtin-modules": "1.1.1",
+                "chalk": "2.4.1",
+                "commander": "2.15.1",
+                "diff": "3.5.0",
+                "glob": "7.1.2",
+                "js-yaml": "3.12.0",
+                "minimatch": "3.0.4",
+                "resolve": "1.7.1",
+                "semver": "5.5.0",
+                "tslib": "1.9.2",
+                "tsutils": "2.27.1"
             }
         },
         "tsutils": {
@@ -5474,7 +5487,7 @@
             "integrity": "sha512-AE/7uzp32MmaHvNNFES85hhUDHFdFZp6OAiZcd6y4ZKKIg6orJTm8keYWBhIhrJQH3a4LzNKat7ZPXZt5aTf6w==",
             "dev": true,
             "requires": {
-                "tslib": "^1.8.1"
+                "tslib": "1.9.2"
             }
         },
         "tty-browserify": {
@@ -5489,7 +5502,7 @@
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "dev": true,
             "requires": {
-                "safe-buffer": "^5.0.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "tweetnacl": {
@@ -5517,8 +5530,8 @@
             "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
             "dev": true,
             "requires": {
-                "commander": "~2.13.0",
-                "source-map": "~0.6.1"
+                "commander": "2.13.0",
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "commander": {
@@ -5541,14 +5554,14 @@
             "integrity": "sha512-hIQJ1yxAPhEA2yW/i7Fr+SXZVMp+VEI3d42RTHBgQd2yhp/1UdBcR3QEWPV5ahBxlqQDMEMTuTEvDHSFINfwSw==",
             "dev": true,
             "requires": {
-                "cacache": "^10.0.4",
-                "find-cache-dir": "^1.0.0",
-                "schema-utils": "^0.4.5",
-                "serialize-javascript": "^1.4.0",
-                "source-map": "^0.6.1",
-                "uglify-es": "^3.3.4",
-                "webpack-sources": "^1.1.0",
-                "worker-farm": "^1.5.2"
+                "cacache": "10.0.4",
+                "find-cache-dir": "1.0.0",
+                "schema-utils": "0.4.5",
+                "serialize-javascript": "1.5.0",
+                "source-map": "0.6.1",
+                "uglify-es": "3.3.9",
+                "webpack-sources": "1.1.0",
+                "worker-farm": "1.6.0"
             },
             "dependencies": {
                 "source-map": {
@@ -5565,10 +5578,10 @@
             "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
             "dev": true,
             "requires": {
-                "arr-union": "^3.1.0",
-                "get-value": "^2.0.6",
-                "is-extendable": "^0.1.1",
-                "set-value": "^0.4.3"
+                "arr-union": "3.1.0",
+                "get-value": "2.0.6",
+                "is-extendable": "0.1.1",
+                "set-value": "0.4.3"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -5577,7 +5590,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 },
                 "set-value": {
@@ -5586,10 +5599,10 @@
                     "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "^2.0.1",
-                        "is-extendable": "^0.1.1",
-                        "is-plain-object": "^2.0.1",
-                        "to-object-path": "^0.3.0"
+                        "extend-shallow": "2.0.1",
+                        "is-extendable": "0.1.1",
+                        "is-plain-object": "2.0.4",
+                        "to-object-path": "0.3.0"
                     }
                 }
             }
@@ -5600,7 +5613,7 @@
             "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
             "dev": true,
             "requires": {
-                "unique-slug": "^2.0.0"
+                "unique-slug": "2.0.0"
             }
         },
         "unique-slug": {
@@ -5609,7 +5622,7 @@
             "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
             "dev": true,
             "requires": {
-                "imurmurhash": "^0.1.4"
+                "imurmurhash": "0.1.4"
             }
         },
         "unique-stream": {
@@ -5618,8 +5631,8 @@
             "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
             "dev": true,
             "requires": {
-                "json-stable-stringify": "^1.0.0",
-                "through2-filter": "^2.0.0"
+                "json-stable-stringify": "1.0.1",
+                "through2-filter": "2.0.0"
             }
         },
         "unset-value": {
@@ -5628,8 +5641,8 @@
             "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
             "dev": true,
             "requires": {
-                "has-value": "^0.3.1",
-                "isobject": "^3.0.0"
+                "has-value": "0.3.1",
+                "isobject": "3.0.1"
             },
             "dependencies": {
                 "has-value": {
@@ -5638,9 +5651,9 @@
                     "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
                     "dev": true,
                     "requires": {
-                        "get-value": "^2.0.3",
-                        "has-values": "^0.1.4",
-                        "isobject": "^2.0.0"
+                        "get-value": "2.0.6",
+                        "has-values": "0.1.4",
+                        "isobject": "2.1.0"
                     },
                     "dependencies": {
                         "isobject": {
@@ -5674,7 +5687,7 @@
             "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
             "dev": true,
             "requires": {
-                "punycode": "^2.1.0"
+                "punycode": "2.1.1"
             }
         },
         "urix": {
@@ -5707,8 +5720,8 @@
             "integrity": "sha512-ERuGxDiQ6Xw/agN4tuoCRbmwRuZP0cJ1lJxJubXr5Q/5cDa78+Dc4wfvtxzhzhkm5VvmW6Mf8EVj9SPGN4l8Lg==",
             "dev": true,
             "requires": {
-                "querystringify": "^2.0.0",
-                "requires-port": "^1.0.0"
+                "querystringify": "2.0.0",
+                "requires-port": "1.0.0"
             }
         },
         "use": {
@@ -5717,7 +5730,7 @@
             "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
             "dev": true,
             "requires": {
-                "kind-of": "^6.0.2"
+                "kind-of": "6.0.2"
             }
         },
         "util": {
@@ -5767,9 +5780,9 @@
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "dev": true,
             "requires": {
-                "assert-plus": "^1.0.0",
+                "assert-plus": "1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "^1.2.0"
+                "extsprintf": "1.3.0"
             }
         },
         "vinyl": {
@@ -5778,8 +5791,8 @@
             "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
             "dev": true,
             "requires": {
-                "clone": "^0.2.0",
-                "clone-stats": "^0.0.1"
+                "clone": "0.2.0",
+                "clone-stats": "0.0.1"
             }
         },
         "vinyl-fs": {
@@ -5788,23 +5801,23 @@
             "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
             "dev": true,
             "requires": {
-                "duplexify": "^3.2.0",
-                "glob-stream": "^5.3.2",
-                "graceful-fs": "^4.0.0",
+                "duplexify": "3.6.0",
+                "glob-stream": "5.3.5",
+                "graceful-fs": "4.1.11",
                 "gulp-sourcemaps": "1.6.0",
-                "is-valid-glob": "^0.3.0",
-                "lazystream": "^1.0.0",
-                "lodash.isequal": "^4.0.0",
-                "merge-stream": "^1.0.0",
-                "mkdirp": "^0.5.0",
-                "object-assign": "^4.0.0",
-                "readable-stream": "^2.0.4",
-                "strip-bom": "^2.0.0",
-                "strip-bom-stream": "^1.0.0",
-                "through2": "^2.0.0",
-                "through2-filter": "^2.0.0",
-                "vali-date": "^1.0.0",
-                "vinyl": "^1.0.0"
+                "is-valid-glob": "0.3.0",
+                "lazystream": "1.0.0",
+                "lodash.isequal": "4.5.0",
+                "merge-stream": "1.0.1",
+                "mkdirp": "0.5.1",
+                "object-assign": "4.1.1",
+                "readable-stream": "2.3.6",
+                "strip-bom": "2.0.0",
+                "strip-bom-stream": "1.0.0",
+                "through2": "2.0.3",
+                "through2-filter": "2.0.0",
+                "vali-date": "1.0.0",
+                "vinyl": "1.2.0"
             },
             "dependencies": {
                 "clone": {
@@ -5825,8 +5838,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "^1.0.0",
-                        "clone-stats": "^0.0.1",
+                        "clone": "1.0.4",
+                        "clone-stats": "0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -5838,8 +5851,8 @@
             "integrity": "sha1-YrU6E1YQqJbpjKlr7jqH8Aio54A=",
             "dev": true,
             "requires": {
-                "through2": "^2.0.3",
-                "vinyl": "^0.4.3"
+                "through2": "2.0.3",
+                "vinyl": "0.4.6"
             }
         },
         "vm-browserify": {
@@ -5857,20 +5870,20 @@
             "integrity": "sha512-SyDw4qFwZ+WthZX7RWp71PNiWLF7VhpM65j2oryY/6jtSORd8qH6J8vclwWZJ6Jvu0EH7JamO2RWNfBfsMR9Zw==",
             "dev": true,
             "requires": {
-                "glob": "^7.1.2",
-                "gulp-chmod": "^2.0.0",
-                "gulp-filter": "^5.0.1",
+                "glob": "7.1.2",
+                "gulp-chmod": "2.0.0",
+                "gulp-filter": "5.1.0",
                 "gulp-gunzip": "1.0.0",
-                "gulp-remote-src-vscode": "^0.5.0",
-                "gulp-symdest": "^1.1.0",
-                "gulp-untar": "^0.0.7",
-                "gulp-vinyl-zip": "^2.1.0",
-                "mocha": "^4.0.1",
-                "request": "^2.83.0",
-                "semver": "^5.4.1",
-                "source-map-support": "^0.5.0",
-                "url-parse": "^1.1.9",
-                "vinyl-source-stream": "^1.1.0"
+                "gulp-remote-src-vscode": "0.5.0",
+                "gulp-symdest": "1.1.0",
+                "gulp-untar": "0.0.7",
+                "gulp-vinyl-zip": "2.1.0",
+                "mocha": "4.1.0",
+                "request": "2.87.0",
+                "semver": "5.5.0",
+                "source-map-support": "0.5.6",
+                "url-parse": "1.4.0",
+                "vinyl-source-stream": "1.1.2"
             }
         },
         "watchpack": {
@@ -5879,9 +5892,9 @@
             "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
             "dev": true,
             "requires": {
-                "chokidar": "^2.0.2",
-                "graceful-fs": "^4.1.2",
-                "neo-async": "^2.5.0"
+                "chokidar": "2.0.3",
+                "graceful-fs": "4.1.11",
+                "neo-async": "2.5.1"
             }
         },
         "webpack": {
@@ -5894,26 +5907,26 @@
                 "@webassemblyjs/wasm-edit": "1.5.9",
                 "@webassemblyjs/wasm-opt": "1.5.9",
                 "@webassemblyjs/wasm-parser": "1.5.9",
-                "acorn": "^5.0.0",
-                "acorn-dynamic-import": "^3.0.0",
-                "ajv": "^6.1.0",
-                "ajv-keywords": "^3.1.0",
-                "chrome-trace-event": "^0.1.1",
-                "enhanced-resolve": "^4.0.0",
-                "eslint-scope": "^3.7.1",
-                "json-parse-better-errors": "^1.0.2",
-                "loader-runner": "^2.3.0",
-                "loader-utils": "^1.1.0",
-                "memory-fs": "~0.4.1",
-                "micromatch": "^3.1.8",
-                "mkdirp": "~0.5.0",
-                "neo-async": "^2.5.0",
-                "node-libs-browser": "^2.0.0",
-                "schema-utils": "^0.4.4",
-                "tapable": "^1.0.0",
-                "uglifyjs-webpack-plugin": "^1.2.4",
-                "watchpack": "^1.5.0",
-                "webpack-sources": "^1.0.1"
+                "acorn": "5.6.1",
+                "acorn-dynamic-import": "3.0.0",
+                "ajv": "6.5.0",
+                "ajv-keywords": "3.2.0",
+                "chrome-trace-event": "0.1.3",
+                "enhanced-resolve": "4.0.0",
+                "eslint-scope": "3.7.1",
+                "json-parse-better-errors": "1.0.2",
+                "loader-runner": "2.3.0",
+                "loader-utils": "1.1.0",
+                "memory-fs": "0.4.1",
+                "micromatch": "3.1.10",
+                "mkdirp": "0.5.1",
+                "neo-async": "2.5.1",
+                "node-libs-browser": "2.1.0",
+                "schema-utils": "0.4.5",
+                "tapable": "1.0.0",
+                "uglifyjs-webpack-plugin": "1.2.5",
+                "watchpack": "1.6.0",
+                "webpack-sources": "1.1.0"
             }
         },
         "webpack-cli": {
@@ -5922,17 +5935,17 @@
             "integrity": "sha512-eAfjI1QNB+fe8F2K7uTWeuhEzd5uu7Dy8PbgiwYbk2LFWlI5k+vVXb5I6ugJcHQxQpVkiHIHw2v1a69AGWcCVA==",
             "dev": true,
             "requires": {
-                "chalk": "^2.4.1",
-                "cross-spawn": "^6.0.5",
-                "enhanced-resolve": "^4.0.0",
-                "global-modules-path": "^2.1.0",
-                "import-local": "^1.0.0",
-                "inquirer": "^5.2.0",
-                "interpret": "^1.1.0",
-                "loader-utils": "^1.1.0",
-                "supports-color": "^5.4.0",
-                "v8-compile-cache": "^2.0.0",
-                "yargs": "^11.1.0"
+                "chalk": "2.4.1",
+                "cross-spawn": "6.0.5",
+                "enhanced-resolve": "4.0.0",
+                "global-modules-path": "2.1.0",
+                "import-local": "1.0.0",
+                "inquirer": "5.2.0",
+                "interpret": "1.1.0",
+                "loader-utils": "1.1.0",
+                "supports-color": "5.4.0",
+                "v8-compile-cache": "2.0.0",
+                "yargs": "11.1.0"
             }
         },
         "webpack-node-externals": {
@@ -5947,8 +5960,8 @@
             "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
             "dev": true,
             "requires": {
-                "source-list-map": "^2.0.0",
-                "source-map": "~0.6.1"
+                "source-list-map": "2.0.0",
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "source-map": {
@@ -5963,9 +5976,8 @@
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
             "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-            "dev": true,
             "requires": {
-                "isexe": "^2.0.0"
+                "isexe": "2.0.0"
             }
         },
         "which-module": {
@@ -5980,7 +5992,7 @@
             "integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
             "dev": true,
             "requires": {
-                "errno": "~0.1.7"
+                "errno": "0.1.7"
             }
         },
         "wrap-ansi": {
@@ -5989,8 +6001,8 @@
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
             "dev": true,
             "requires": {
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1"
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1"
             },
             "dependencies": {
                 "is-fullwidth-code-point": {
@@ -5999,7 +6011,7 @@
                     "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                     "dev": true,
                     "requires": {
-                        "number-is-nan": "^1.0.0"
+                        "number-is-nan": "1.0.1"
                     }
                 },
                 "string-width": {
@@ -6008,9 +6020,9 @@
                     "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                     "dev": true,
                     "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
                     }
                 }
             }
@@ -6036,8 +6048,7 @@
         "yallist": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-            "dev": true
+            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
         },
         "yargs": {
             "version": "11.1.0",
@@ -6045,18 +6056,18 @@
             "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
             "dev": true,
             "requires": {
-                "cliui": "^4.0.0",
-                "decamelize": "^1.1.1",
-                "find-up": "^2.1.0",
-                "get-caller-file": "^1.0.1",
-                "os-locale": "^2.0.0",
-                "require-directory": "^2.1.1",
-                "require-main-filename": "^1.0.1",
-                "set-blocking": "^2.0.0",
-                "string-width": "^2.0.0",
-                "which-module": "^2.0.0",
-                "y18n": "^3.2.1",
-                "yargs-parser": "^9.0.2"
+                "cliui": "4.1.0",
+                "decamelize": "1.2.0",
+                "find-up": "2.1.0",
+                "get-caller-file": "1.0.2",
+                "os-locale": "2.1.0",
+                "require-directory": "2.1.1",
+                "require-main-filename": "1.0.1",
+                "set-blocking": "2.0.0",
+                "string-width": "2.1.1",
+                "which-module": "2.0.0",
+                "y18n": "3.2.1",
+                "yargs-parser": "9.0.2"
             },
             "dependencies": {
                 "y18n": {
@@ -6073,7 +6084,7 @@
             "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
             "dev": true,
             "requires": {
-                "camelcase": "^4.1.0"
+                "camelcase": "4.1.0"
             }
         },
         "yauzl": {
@@ -6082,8 +6093,8 @@
             "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
             "dev": true,
             "requires": {
-                "buffer-crc32": "~0.2.3",
-                "fd-slicer": "~1.0.1"
+                "buffer-crc32": "0.2.13",
+                "fd-slicer": "1.0.1"
             }
         },
         "yazl": {
@@ -6092,7 +6103,7 @@
             "integrity": "sha1-7CblzIfVYBud+EMtvdPNLlFzoHE=",
             "dev": true,
             "requires": {
-                "buffer-crc32": "~0.2.3"
+                "buffer-crc32": "0.2.13"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -3232,7 +3232,7 @@
         "vscode:prepublish": "npm run reset && npm run bundle"
     },
     "dependencies": {
-        "copy-paste": "1.3.0",
+        "clipboardy": "1.2.3",
         "date-fns": "1.29.0",
         "iconv-lite": "0.4.23",
         "lodash.debounce": "4.0.8",
@@ -3241,7 +3241,7 @@
         "tslib": "1.9.2"
     },
     "devDependencies": {
-        "@types/copy-paste": "1.1.30",
+        "@types/clipboardy": "1.1.0",
         "@types/node": "7.0.65",
         "@types/tmp": "0.0.33",
         "husky": "0.14.3",


### PR DESCRIPTION
I replaced [copy-paste](https://github.com/xavi-/node-copy-paste) by [clipboardy](https://github.com/sindresorhus/clipboardy).
>It is more actively maintained and it fixes many of that module's issues.
https://stackoverflow.com/a/43153941/2787235

Ref #35