### PR TITLE
Add the gitlens.hovers.avatars configuration option

### DIFF
--- a/package.json
+++ b/package.json
@@ -599,6 +599,12 @@
                     "description": "Specifies when to trigger hovers for the current line\n `annotation` - only shown when hovering over the line annotation\n `line` - shown when hovering anywhere over the line",
                     "scope": "window"
                 },
+                "gitlens.hovers.avatars": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Specifies whether to show avatar images in hovers",
+                    "scope": "window"
+                },
                 "gitlens.hovers.enabled": {
                     "type": "boolean",
                     "default": true,

--- a/src/annotations/annotations.ts
+++ b/src/annotations/annotations.ts
@@ -96,6 +96,7 @@ export class Annotations {
         let message = '';
         let commandBar = '';
         let showCommitDetailsCommand = '';
+        let avatar = '';
         if (!commit.isUncommitted) {
             commandBar = `\n\n${this.getHoverCommandBar(commit, remotes.length !== 0, annotationType, line)}`;
             showCommitDetailsCommand = `[\`${commit.shortSha}\`](${ShowQuickCommitDetailsCommand.getMarkdownCommandArgs(commit.sha)} "Show Commit Details")`;
@@ -121,7 +122,11 @@ export class Annotations {
             showCommitDetailsCommand = `\`${commit.shortSha === 'working' ? '00000000' : commit.shortSha}\``;
         }
 
-        const markdown = new MarkdownString(`${showCommitDetailsCommand} &nbsp; ![](${commit.getGravatarUri(Container.config.defaultGravatarsStyle).toString()}) &nbsp;__${commit.author}__, ${commit.fromNow()} &nbsp; _(${commit.formatDate(dateFormat)})_ ${message}${commandBar}`);
+        if (Container.config.hovers.avatars) {
+            avatar = ` &nbsp; ![](${commit.getGravatarUri(Container.config.defaultGravatarsStyle).toString()})`;
+        }
+
+        const markdown = new MarkdownString(`${showCommitDetailsCommand}${avatar} &nbsp;__${commit.author}__, ${commit.fromNow()} &nbsp; _(${commit.formatDate(dateFormat)})_ ${message}${commandBar}`);
         markdown.isTrusted = true;
         return markdown;
     }

--- a/src/ui/config.ts
+++ b/src/ui/config.ts
@@ -322,6 +322,7 @@ export interface IConfig {
             over: 'line' | 'annotation'
         };
 
+        avatars: boolean;
         enabled: boolean;
     };
 


### PR DESCRIPTION
This setting allows disabling/enabling showing avatars in hovers. We already have settings for the explorer and blame gutter, so it makes sense to also have one for the hovers.