### PR TITLE
Replace `--` with `—` in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1198,7 +1198,7 @@
                 "gitlens.advanced.caching.enabled": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Specifies whether git output will be cached -- changing the default is not recommended",
+                    "description": "Specifies whether git output will be cached — changing the default is not recommended",
                     "scope": "window"
                 },
                 "gitlens.advanced.git": {
@@ -1210,7 +1210,7 @@
                 "gitlens.advanced.fileHistoryFollowsRenames": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Specifies whether file histories will follow renames -- will affect how merge commits are shown in histories",
+                    "description": "Specifies whether file histories will follow renames — will affect how merge commits are shown in histories",
                     "scope": "window"
                 },
                 "gitlens.advanced.maxListItems": {


### PR DESCRIPTION
Double hyphen is a poor em dash replacement in the monospace font. `--` were replaced with `—` in the configuration properties descriptions.