### PR TITLE
Make Azure Pipelines use document scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -246,6 +246,12 @@
                     "type": "array",
                     "default": [
                         {
+                            "language": "azure-pipelines",
+                            "scopes": [
+                                "document"
+                            ]
+                        },
+                        {
                             "language": "css",
                             "scopes": [
                                 "document"


### PR DESCRIPTION
Hi. I'm a PM on Azure Pipelines. One of the features we've just shipped is an [extension for VS Code](https://github.com/Microsoft/azure-pipelines-vscode) to make it easier to author in our YAML-based format. For some reason, the same document parsed as YAML shows the right amount of GitLens entries, but when I switch over to treat it as Azure Pipelines, way too many entries get injected.

If there's a different way to solve this, I'm all for it! But this seemed to fix it properly in my local workspace settings, and I think it should be the default for GitLens users.

Thanks!