### PR TITLE
Gravartars not showing if email contained upper case characters

### DIFF
--- a/src/git/models/commit.ts
+++ b/src/git/models/commit.ts
@@ -186,7 +186,7 @@ export abstract class GitCommit {
 
         gravatar = Uri.parse(
             `https://www.gravatar.com/avatar/${
-                this.email ? Strings.md5(this.email, 'hex') : '00000000000000000000000000000000'
+                this.email ? Strings.md5(this.email.trim().toLowerCase(), 'hex') : '00000000000000000000000000000000'
             }.jpg?s=${size}&d=${fallback}`
         );
         gravatarCache.set(key, gravatar);


### PR DESCRIPTION
The email address was being correctly manipulated for the lookup of the Gravatar from local cache, but when the call to Gravatar was made for one that wasn't in the local cache the email was not being run via `trim()` and `toLowerCase()`.

This has been causing the avatars to fail to show for valid accounts.