### PR TITLE
[Fixes #608] Adds the option to change the length of the abbreviated commit SHA

### DIFF
--- a/README.md
+++ b/README.md
@@ -841,7 +841,8 @@ See also [View Settings](#view-settings- 'Jump to the View settings')
 ### Advanced Settings [#](#advanced-settings- 'Advanced Settings')
 
 | Name                                            | Description                                                                                                                           |
-| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------|
+| `gitlens.advanced.abbreviatedShaLength`         | Specifies the length of the abbreviated commit SHA (a.k.a. commit ID). Default is 7.
 | `gitlens.advanced.blame.customArguments`        | Specifies additional arguments to pass to the `git blame` command                                                                     |
 | `gitlens.advanced.blame.delayAfterEdit`         | Specifies the time (in milliseconds) to wait before re-blaming an unsaved document after an edit. Use 0 to specify an infinite wait   |
 | `gitlens.advanced.blame.sizeThresholdAfterEdit` | Specifies the maximum document size (in lines) allowed to be re-blamed after an edit while still unsaved. Use 0 to specify no maximum |

--- a/package.json
+++ b/package.json
@@ -1583,6 +1583,12 @@
                     "markdownDescription": "Specifies the description format of the status of a working or committed file in the views\n- Available tokens\n - `${directory}` &mdash; directory name\n - `${file}` &mdash; file name\n - `${filePath}` &mdash; formatted file name and path\n - `${path}` &mdash; full file path\n - `${working}` &mdash; optional indicator if the file is uncommitted",
                     "scope": "window"
                 },
+                "gitlens.advanced.abbreviatedShaLength": {
+                    "type": "number",
+                    "default": "7",
+                    "markdownDescription": "Specifies the length of the abbreviated commit SHA (a.k.a. commit ID). Default is 7.",
+                    "scope": "window"
+                },
                 "gitlens.advanced.blame.customArguments": {
                     "type": "array",
                     "default": null,

--- a/src/git/git.ts
+++ b/src/git/git.ts
@@ -285,9 +285,9 @@ export class Git {
         if (index > 5) {
             // Only grab a max of 5 chars for the suffix
             const suffix = ref.substring(index).substring(0, 5);
-            return `${ref.substring(0, 7 - suffix.length)}${suffix}`;
+            return `${ref.substring(0, Container.config.advanced.abbreviatedShaLength - suffix.length)}${suffix}`;
         }
-        return ref.substring(0, 7);
+        return ref.substring(0, Container.config.advanced.abbreviatedShaLength);
     }
 
     static splitPath(fileName: string, repoPath: string | undefined, extract: boolean = true): [string, string] {

--- a/src/ui/config.ts
+++ b/src/ui/config.ts
@@ -186,6 +186,7 @@ export enum ViewFilesLayout {
 }
 
 export interface AdvancedConfig {
+    abbreviatedShaLength: number;
     blame: {
         customArguments: string[] | null;
         delayAfterEdit: number;


### PR DESCRIPTION
# Description

I am working on a documentation project that I have made a spreadsheet planner for, and entering the ID of the latest commit touching a given feature is required. Since the project is on GitLab, and said Git host has 8-character-long commit abbreviations, I have gotten used to the 8-character length. However, while pasting the commit ID from GitLens, I was surprised to find that it was only 7, which also frustrated me. This PR aims to allow the user to change the length of the abbreviated commit SHA, and relieve the frustration caused by inconsistencies in abbreviated commit ID length across multiple Git clients/hosts/software.

# Checklist

- [x] I have followed the guidelines in the Contributing document
- [x] My changes are based off of the `develop` branch
- [x] My changes follow the coding style of this project
- [ ] My changes build without any errors or warnings (are linebreak and `no-floating-promises` warnings considered as such?)
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
