### PR TITLE
Fixes #620: Add missing _git in Azure DevOps URLs.

### DIFF
--- a/src/git/parsers/remoteParser.ts
+++ b/src/git/parsers/remoteParser.ts
@@ -68,15 +68,17 @@ export class GitRemoteParser {
             const uniqueness = `${domain}/${path}`;
             let remote: GitRemote | undefined = groups[uniqueness];
             if (remote === undefined) {
+                const provider = providerFactory(domain, path);
+
                 remote = new GitRemote(
                     repoPath,
                     uniqueness,
                     // Stops excessive memory usage -- https://bugs.chromium.org/p/v8/issues/detail?id=2869
                     (' ' + match[1]).substr(1),
                     scheme,
-                    domain,
-                    path,
-                    providerFactory(domain, path),
+                    provider !== undefined ? provider.domain : domain,
+                    provider !== undefined ? provider.path : path,
+                    provider,
                     // Stops excessive memory usage -- https://bugs.chromium.org/p/v8/issues/detail?id=2869
                     [{ url: url, type: (' ' + match[3]).substr(1) as GitRemoteType }]
                 );

--- a/src/git/remotes/azure-devops.ts
+++ b/src/git/remotes/azure-devops.ts
@@ -11,9 +11,14 @@ const sshPathRegex = /^\/?v\d\//i;
 export class AzureDevOpsRemote extends RemoteProvider {
     constructor(domain: string, path: string, protocol?: string, name?: string) {
         domain = domain.replace(sshDomainRegex, '');
-        path = path.replace(sshPathRegex, '');
+        path = path.replace(sshPathRegex, '').replace(stripGitRegex, '/');
 
         super(domain, path, protocol, name);
+    }
+
+    get baseUrl() {
+        const [orgAndProject, repo] = this.splitPath();
+        return `https://${this.domain}/${orgAndProject}/_git/${repo}`;
     }
 
     get icon() {
@@ -58,4 +63,10 @@ export class AzureDevOpsRemote extends RemoteProvider {
         if (branch) return `${this.baseUrl}/?path=%2F${fileName}&version=GB${branch}&_a=contents${line}`;
         return `${this.baseUrl}?path=%2F${fileName}${line}`;
     }
+
+    protected splitPath(): [string, string] {
+        const index = this.path.lastIndexOf('/');
+        return [this.path.substring(0, index), this.path.substring(index + 1)];
+    }
+
 }

--- a/src/git/remotes/factory.ts
+++ b/src/git/remotes/factory.ts
@@ -19,7 +19,10 @@ const defaultProviders: RemoteProviders = [
     [/\bdev\.azure\.com$/i, (domain: string, path: string) => new AzureDevOpsRemote(domain, path)],
     [/\bbitbucket\b/i, (domain: string, path: string) => new BitbucketServerRemote(domain, path)],
     [/\bgitlab\b/i, (domain: string, path: string) => new GitLabRemote(domain, path)],
-    [/\bvisualstudio\.com$/i, (domain: string, path: string) => new AzureDevOpsRemote(domain, path)]
+    [
+        /\bvisualstudio\.com$/i,
+        (domain: string, path: string) => new AzureDevOpsRemote(domain, path, undefined, undefined, true)
+    ]
 ];
 
 export class RemoteProviderFactory {

--- a/src/git/remotes/provider.ts
+++ b/src/git/remotes/provider.ts
@@ -80,6 +80,10 @@ export abstract class RemoteProvider {
         return 'remote';
     }
 
+    get displayPath(): string {
+        return this.path;
+    }
+
     abstract get name(): string;
 
     protected get baseUrl() {

--- a/src/views/nodes/remoteNode.ts
+++ b/src/views/nodes/remoteNode.ts
@@ -90,7 +90,9 @@ export class RemoteNode extends ViewNode<RepositoriesView> {
         );
         item.description = `${separator}${GlyphChars.Space} ${
             this.remote.provider !== undefined ? this.remote.provider.name : this.remote.domain
-        } ${GlyphChars.Space}${GlyphChars.Dot}${GlyphChars.Space} ${this.remote.path}`;
+        } ${GlyphChars.Space}${GlyphChars.Dot}${GlyphChars.Space} ${
+            this.remote.provider !== undefined ? this.remote.provider.displayPath : this.remote.path
+        }`;
         item.contextValue = ResourceType.Remote;
         if (this.remote.default) {
             item.contextValue += '+default';
@@ -110,9 +112,13 @@ export class RemoteNode extends ViewNode<RepositoriesView> {
         }
 
         item.id = this.id;
-        item.tooltip = `${this.remote.name}\n${this.remote.path} (${
+        item.tooltip = `${this.remote.name} (${
             this.remote.provider !== undefined ? this.remote.provider.name : this.remote.domain
-        })`;
+        })\n${this.remote.provider !== undefined ? this.remote.provider.displayPath : this.remote.path}\n`;
+
+        for (const type of this.remote.types) {
+            item.tooltip += `\n${type.url} (${type.type})`;
+        }
 
         return item;
     }


### PR DESCRIPTION
# Description
This PR fixes the missing _git issue mentioned in #620 

But it _doesn't_ fix the issue cause by the following cloning URL which requires reformatting the domain. 
`<org>@vs-ssh.visualstudio.com:v3/<org>/<project>/<repo>`


About the linting, there's a warning but it's not introduced by this PR. 
```bash
WARNING: vscode-gitlens/src/vsls/host.ts:78:9 - Promises must be handled appropriately
```
<!--
Please include a summary of the changes and which issue will be addressed. Please also include relevant motivation and context.
-->

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes are based off of the `develop` branch
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
