### PR TITLE
Avoid using objects to implement Map

### DIFF
--- a/src/system/array.ts
+++ b/src/system/array.ts
@@ -85,7 +85,7 @@ export namespace Arrays {
         value?: T;
 
         // parent?: IHierarchicalItem<T>;
-        children: { [key: string]: IHierarchicalItem<T> } | undefined;
+        children: Map<string, IHierarchicalItem<T>> | undefined;
         descendants: T[] | undefined;
     }
 
@@ -98,7 +98,7 @@ export namespace Arrays {
         const seed = {
             name: '',
             relativePath: '',
-            children: Object.create(null),
+            children: new Map(),
             descendants: []
         };
 
@@ -110,18 +110,19 @@ export namespace Arrays {
                 relativePath = joinPath(relativePath, folderName);
 
                 if (folder.children === undefined) {
-                    folder.children = Object.create(null);
+                    folder.children = new Map();
                 }
 
-                let f = folder.children![folderName];
+                let f = folder.children!.get(folderName);
                 if (f === undefined) {
-                    folder.children![folderName] = f = {
+                    f = {
                         name: folderName,
                         relativePath: relativePath,
                         // parent: folder,
                         children: undefined,
                         descendants: undefined
                     };
+                    folder.children.set(folderName, f);
                 }
 
                 if (folder.descendants === undefined) {
@@ -147,7 +148,7 @@ export namespace Arrays {
     ): IHierarchicalItem<T> {
         if (root.children === undefined) return root;
 
-        const children = [...Objects.values(root.children)];
+        const children = [...root.children.values()];
 
         // // Attempts less nesting but duplicate roots
         // if (!isRoot && children.every(c => c.value === undefined)) {

--- a/src/views/nodes/branchOrTagFolderNode.ts
+++ b/src/views/nodes/branchOrTagFolderNode.ts
@@ -32,7 +32,7 @@ export class BranchOrTagFolderNode extends ViewNode {
 
         const children: (BranchOrTagFolderNode | BranchNode | TagNode)[] = [];
 
-        for (const folder of Objects.values(this.root.children)) {
+        for (const folder of this.root.children.values()) {
             if (folder.value === undefined) {
                 // If the folder contains the current branch, expand it by default
                 const expanded =

--- a/src/views/nodes/folderNode.ts
+++ b/src/views/nodes/folderNode.ts
@@ -41,7 +41,7 @@ export class FolderNode extends ViewNode<ViewWithFiles> {
         );
         if (nesting !== ViewFilesLayout.List) {
             children = [];
-            for (const folder of Objects.values(this.root.children)) {
+            for (const folder of this.root.children.values()) {
                 if (folder.value === undefined) {
                     children.push(
                         new FolderNode(


### PR DESCRIPTION
This commit occurring with branch names which are parsable integers. 

They were always shown first in the list of branches (even if they are
not starred) because the chrome implementation does not respect the
insertion order for keys that happen to be parseable integers.

It fixes Issue #626. 

# Checklist

- [X] I have followed the guidelines in the Contributing document
- [X] My changes are based off of the `develop` branch
- [X] My changes follow the coding style of this project
- [X] My changes build without any errors or warnings
- [X] My changes have been formatted and linted
- [X] My changes include any required corresponding changes to the documentation
- [X] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses