### PR TITLE
[Readme][VSLS Badge]: change aka.ms link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![](https://vsmarketplacebadge.apphb.com/version-short/eamodio.gitlens.svg)](https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens)
 [![](https://vsmarketplacebadge.apphb.com/downloads-short/eamodio.gitlens.svg)](https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens)
 [![](https://vsmarketplacebadge.apphb.com/rating-short/eamodio.gitlens.svg)](https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens)
-[![](https://aka.ms/vsls-badge)](https://aka.ms/vsls)
+[![](https://aka.ms/vsls-badge)](https://aka.ms/vsls-gitlens)
 [![](https://img.shields.io/badge/vscode--dev--community-gitlens-blue.svg?logo=slack&labelColor=555555)](https://vscode-slack.amod.io)
 
 <p align="center">


### PR DESCRIPTION
The PR adds dedicated `GitLens` aka.ms link to the Live Share badge in `readme.md`.

-- 

I thought this is a too small change to create an issue for it, please let me know if you think otherwise.