### PR TITLE
Fixes #692 - make remote work with recent versions of Bitbucket Server

### DIFF
--- a/src/git/remotes/bitbucket-server.ts
+++ b/src/git/remotes/bitbucket-server.ts
@@ -11,8 +11,8 @@ export class BitbucketServerRemote extends RemoteProvider {
     }
 
     protected get baseUrl() {
-        const [project, repo] = this.splitPath();
-        return `https://${this.domain}/projects/${project}/repos/${repo}`;
+        const [project, repo] = this.path.startsWith('scm/') ? this.path.replace('scm/', '').split('/') : this.splitPath();
+        return `${this.protocol}://${this.domain}/projects/${project}/repos/${repo}`;
     }
 
     get icon() {


### PR DESCRIPTION
# Description

recent versions of Bitbucket server (formerly Stash) introduce an extra /scm in the URL, compared to older versions.
If it's detected in the path it's removed, therefore should work with all versions of Bitbucket server.
Tested with BB v6.1.2

# Checklist

<!-- Please check off the following -->

- [x ] I have followed the guidelines in the Contributing document
- [x ] My changes are based off of the `develop` branch
- [x ] My changes follow the coding style of this project
- [x ] My changes build without any errors or warnings
- [x ] My changes have been formatted and linted
- [x ] My changes include any required corresponding changes to the documentation
- [x ] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x ] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
