### PR TITLE
Fix bug when repoPath & fileName differ in suffix

### DIFF
--- a/src/git/gitUri.ts
+++ b/src/git/gitUri.ts
@@ -1,5 +1,6 @@
 'use strict';
 /* eslint-disable constructor-super */
+import * as url from 'url';
 import * as paths from 'path';
 import { Uri } from 'vscode';
 import { UriComparer } from '../comparers';
@@ -365,7 +366,7 @@ export class GitUri extends ((Uri as any) as UriEx) {
 
         if (normalizedFileName.startsWith(normalizedRepoPath)) return normalizedFileName;
 
-        return Strings.normalizePath(paths.join(normalizedRepoPath, normalizedFileName));
+        return Strings.normalizePath(url.resolve(repoPath, fileName));
     }
 
     static resolveToUri(fileName: string, repoPath?: string) {


### PR DESCRIPTION
# Description

This bug can be simply reproduced :
"/x" is a symlink to "/y",  repoPath is "/y" and fileName is somehow /x/file1.
Joining them will give the wrong path "/y/x/file1".

# Checklist

- [x] I have followed the guidelines in the Contributing document
- [x] My changes are based off of the `develop` branch
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
