### PR TITLE
Adds feature to add remote repository. Fixes #694

### DIFF
--- a/package.json
+++ b/package.json
@@ -2374,6 +2374,15 @@
                 }
             },
             {
+                "command": "gitlens.views.addRemote",
+                "title": "Add Remote",
+                "category": "GitLens",
+                "icon": {
+                    "dark": "images/dark/icon-add.svg",
+                    "light": "images/light/icon-add.svg"
+                }
+            },
+            {
                 "command": "gitlens.views.fetch",
                 "title": "Fetch",
                 "category": "GitLens",
@@ -4255,6 +4264,11 @@
                 {
                     "command": "gitlens.views.checkout",
                     "when": "!gitlens:readonly && viewItem =~ /gitlens:branch/",
+                    "group": "inline@10"
+                },
+                {
+                    "command": "gitlens.views.addRemote",
+                    "when": "viewItem =~ /gitlens:remotes\\b/",
                     "group": "inline@10"
                 },
                 {

--- a/src/git/git.ts
+++ b/src/git/git.ts
@@ -471,6 +471,10 @@ export class Git {
         return git<string>({ cwd: repoPath }, ...params);
     }
 
+    static addRemote(repoPath: string, branchName: string, remoteUrl: string) {
+        return git<string>({ cwd: repoPath },'remote', 'add', branchName, remoteUrl);
+    }
+
     static async config__get(key: string, repoPath?: string, options: { local?: boolean } = {}) {
         const data = await git<string>(
             { cwd: repoPath || emptyStr, errors: GitErrorHandling.Ignore, local: options.local },

--- a/src/git/gitService.ts
+++ b/src/git/gitService.ts
@@ -507,6 +507,12 @@ export class GitService implements Disposable {
 
     @gate()
     @log()
+    addRemote(repoPath: string, branchName: string, remoteUrl: string) {
+        return Git.addRemote(repoPath, branchName, remoteUrl);
+    }
+
+    @gate()
+    @log()
     fetch(repoPath: string, options: { all?: boolean; prune?: boolean; remote?: string } = {}) {
         return Git.fetch(repoPath, options);
     }

--- a/src/views/viewCommands.ts
+++ b/src/views/viewCommands.ts
@@ -114,6 +114,7 @@ export class ViewCommands {
         commands.registerCommand('gitlens.views.openChangedFileRevisions', this.openChangedFileRevisions, this);
         commands.registerCommand('gitlens.views.applyChanges', this.applyChanges, this);
         commands.registerCommand('gitlens.views.checkout', this.checkout, this);
+        commands.registerCommand('gitlens.views.addRemote', this.addRemote, this);
 
         commands.registerCommand('gitlens.views.stageDirectory', this.stageDirectory, this);
         commands.registerCommand('gitlens.views.stageFile', this.stageFile, this);
@@ -278,6 +279,26 @@ export class ViewCommands {
         }
 
         return Container.git.checkout(node.repoPath, node.ref);
+    }
+
+    private async addRemote(node: RemoteNode) {
+        const branchName = await window.showInputBox({
+            prompt: "Please provide a name for the remote branch (Press 'Enter' to confirm or 'Escape' to cancel)",
+            placeHolder: 'Remote branch name',
+            value: undefined
+        });
+
+        if( branchName === undefined || branchName.length === 0) return undefined;
+
+        const remoteUrl = await window.showInputBox({
+            prompt: "Please provide a url for the remote branch (Press 'Enter' to confirm or 'Escape' to cancel)",
+            placeHolder: 'Remote branch url',
+            value: undefined
+        });
+
+        if (remoteUrl === undefined || remoteUrl.length === 0) return undefined;
+
+        return Container.git.addRemote(node.repo.path, branchName, remoteUrl);
     }
 
     private closeRepository(node: RepositoryNode) {


### PR DESCRIPTION
# Description

A feature request for this was made in #694
This change allows the user to add a remote repository from the side bar. Prompts for the desired `branchName` and `remoteUrl` are shown in the command palette area, and pressing <kbd>esc</kbd> cancels at any time

# Screenshots

![image](https://user-images.githubusercontent.com/33520963/61990345-bdaf7700-b00c-11e9-991f-06c90d8a1448.png)

![image](https://user-images.githubusercontent.com/33520963/61990358-09622080-b00d-11e9-87bc-f83c05593ac5.png)

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes are based off of the `develop` branch
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
