### PR TITLE
Uses GitHub Avatar for GH 'noreply' email address

### DIFF
--- a/src/avatars.ts
+++ b/src/avatars.ts
@@ -15,6 +15,14 @@ export function clearGravatarCache() {
     gravatarCache.clear();
 }
 
+function getAvatarFromGithubNoreplyAddress(email: string | undefined, size: number = 16): Uri | undefined {
+    if (!email) return undefined;
+    const match = email.match(/^(?:(?<userId>\d+)\+)?(?<userName>[a-zA-Z\d-]{1,39})@users.noreply.github.com$/);
+    if (!match || !match.groups) return undefined;
+    const { userName, userId } = match.groups;
+    return Uri.parse(`https://avatars.githubusercontent.com/${userId ? `u/${userId}` : userName}?size=${size}`);
+}
+
 export function getGravatarUri(email: string | undefined, fallback: GravatarDefaultStyle, size: number = 16): Uri {
     const hash =
         email != null && email.length !== 0 ? Strings.md5(email.trim().toLowerCase(), 'hex') : missingGravatarHash;
@@ -23,7 +31,9 @@ export function getGravatarUri(email: string | undefined, fallback: GravatarDefa
     let gravatar = gravatarCache.get(key);
     if (gravatar !== undefined) return gravatar;
 
-    gravatar = Uri.parse(`https://www.gravatar.com/avatar/${hash}.jpg?s=${size}&d=${fallback}`);
+    gravatar =
+        getAvatarFromGithubNoreplyAddress(email, size) ||
+        Uri.parse(`https://www.gravatar.com/avatar/${hash}.jpg?s=${size}&d=${fallback}`);
     gravatarCache.set(key, gravatar);
 
     return gravatar;


### PR DESCRIPTION
# Description

Partial fix for #281 - covers the `*@users.noreply.github.com` case.

The `users.noreply.github.com` domain comes from users
making use GitHub's 'email privacy' feature.
Since the noreply address doesn't accept email, a user can't link
their preferred Gravatar to this type of email address.

The upside is that this address is easily parseable into:
* (optional) Github User ID
* Github User Name

We can use either to create the associated avatar link
without actually having to do an additional request
against Github's user search API.

Example changes from "contributors" list of this repository:
![Before](https://user-images.githubusercontent.com/3034257/62569808-07922b80-b85d-11e9-82e4-8f8016b30c25.png)
-> 
![After](https://user-images.githubusercontent.com/3034257/62569941-2a244480-b85d-11e9-87e5-6f5c6acd77b0.png)

# Checklist

- [x] I have followed the guidelines in the Contributing document
- [x] My changes are based off of the `develop` branch
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
