### PR TITLE
Adds feature to prune remotes. Fixes #556

### DIFF
--- a/package.json
+++ b/package.json
@@ -2416,6 +2416,11 @@
                 }
             },
             {
+                "command": "gitlens.views.pruneRemote",
+                "title": "Prune",
+                "category": "GitLens"
+            },
+            {
                 "command": "gitlens.views.fetch",
                 "title": "Fetch",
                 "category": "GitLens",
@@ -3390,6 +3395,10 @@
                 },
                 {
                     "command": "gitlens.views.checkout",
+                    "when": "false"
+                },
+                {
+                    "command": "gitlens.views.pruneRemote",
                     "when": "false"
                 },
                 {
@@ -4697,6 +4706,11 @@
                     "command": "gitlens.views.fetch",
                     "when": "!gitlens:readonly && viewItem =~ /gitlens:remote\\b/",
                     "group": "1_gitlens@1"
+                },
+                {
+                    "command": "gitlens.views.pruneRemote",
+                    "when": "!gitlens:readonly && viewItem =~ /gitlens:remote\\b/",
+                    "group": "1_gitlens@2"
                 },
                 {
                     "command": "gitlens.openRepoInRemote",

--- a/src/git/git.ts
+++ b/src/git/git.ts
@@ -891,6 +891,10 @@ export class Git {
         return git<string>({ cwd: repoPath }, 'remote', 'add', name, url);
     }
 
+    static remote__prune(repoPath: string, remoteName: string) {
+        return git<string>({ cwd: repoPath }, 'remote', 'prune', remoteName);
+    }
+
     static remote__get_url(repoPath: string, remote: string): Promise<string> {
         return git<string>({ cwd: repoPath }, 'remote', 'get-url', remote);
     }

--- a/src/git/gitService.ts
+++ b/src/git/gitService.ts
@@ -463,6 +463,11 @@ export class GitService implements Disposable {
     }
 
     @log()
+    pruneRemote(repoPath: string, remoteName: string) {
+        return Git.remote__prune(repoPath, remoteName);
+    }
+
+    @log()
     async applyChangesToWorkingFile(uri: GitUri, ref1?: string, ref2?: string) {
         const cc = Logger.getCorrelationContext();
 

--- a/src/views/viewCommands.ts
+++ b/src/views/viewCommands.ts
@@ -115,6 +115,7 @@ export class ViewCommands {
         commands.registerCommand('gitlens.views.applyChanges', this.applyChanges, this);
         commands.registerCommand('gitlens.views.checkout', this.checkout, this);
         commands.registerCommand('gitlens.views.addRemote', this.addRemote, this);
+        commands.registerCommand('gitlens.views.pruneRemote', this.pruneRemote, this);
 
         commands.registerCommand('gitlens.views.stageDirectory', this.stageDirectory, this);
         commands.registerCommand('gitlens.views.stageFile', this.stageFile, this);
@@ -290,6 +291,13 @@ export class ViewCommands {
         void (await node.repo.fetch({ remote: name }));
 
         return name;
+    }
+
+    private async pruneRemote(node: RemoteNode) {
+        const remoteName = node.remote.name;
+        void (await Container.git.pruneRemote(node.repo.path, remoteName));
+
+        return remoteName;
     }
 
     private closeRepository(node: RepositoryNode) {


### PR DESCRIPTION
# Description     

A request for the option to prune a remote was made in #556 
There was some discussion as to the exact functionality that people wanted:

The main concern I believe was to simply prune the remote

There was also talk to remove any local branches tracking pruned remote branches, which I thought might be better for a feature separate from pruning, as it alters the local repo in a way most would not expect

**EDIT:** it was agreed upon in #556 that this feature should just prune the remote. A new issue to implement the second functionality was made at #817 

Also, I wasn't sure which icon to use, but thought that the `icon-branch.svg` fit the best. I can change this if people wish

## Testing
To test this feature with my test gitlab repo, I did the following:
1 - create a new remote branch on gitlab, and add a file to it
2 - from gitlens, fetch the remote to which I made these changes. Make sure the remote branch is seen
3 - merge the remote branch into remote master and delete on merging
4 - pull from the remote
5 - run `git remote prune --dry-run <remoteName>` to ensure there was indeed a branch to prune
6 - use the "prune" functionality added in gitlens
7 - check to make sure the remote branch disappears in gitlens. Also run another `git remote prune --dry-run <remoteName>` just to be safe

## Screenshots:

![image](https://user-images.githubusercontent.com/33520963/62594043-1271ae00-b8a7-11e9-9b31-4163d7b28933.png)

**steps 1 and 2** (feature-pr remote branch is still in remote)

![image](https://user-images.githubusercontent.com/33520963/62594073-37662100-b8a7-11e9-84d2-c78843e609bf.png)

**step 3**

![image](https://user-images.githubusercontent.com/33520963/62594154-74321800-b8a7-11e9-8785-bf2650eff957.png)

**steps 4 and 5** (check that there is indeed a branch to prune)

![image](https://user-images.githubusercontent.com/33520963/62594205-a17ec600-b8a7-11e9-8090-5ce229f55b63.png)

![image](https://user-images.githubusercontent.com/33520963/62594252-da1e9f80-b8a7-11e9-9c30-8663fe385035.png)

**step 6 and 7** (after pressing the "prune" button in gitlens)

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes are based off of the `develop` branch
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
