### PR TITLE
Fixes #893 - unquoted branch names in merge

### DIFF
--- a/src/git/models/repository.ts
+++ b/src/git/models/repository.ts
@@ -652,7 +652,8 @@ export class Repository implements Disposable {
 	}
 
 	private runTerminalCommand(command: string, ...args: any[]) {
-		runGitCommandInTerminal(command, args.join(' '), this.path, true);
+		const parsedArgs = args.map(arg => (arg.indexOf('#') >= 0 ? `"${arg}"` : arg));
+		runGitCommandInTerminal(command, parsedArgs.join(' '), this.path, true);
 		if (!this.supportsChangeEvents) {
 			this.fireChange(RepositoryChange.Repository);
 		}


### PR DESCRIPTION
# Description

I try to fix issue #893. Branch names are quoted now, while merging:
`git merge "#test"`. Before the generated command called: `git merge "#test"` wich does nothing, as `#` works like a comment in bash.
<!--
Please include a summary of the changes and which issue will be addressed. Please also include relevant motivation and context.
-->



# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes are based off of the `develop` branch
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [ ] My changes include any required corresponding changes to the documentation
- [ ] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [ ] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
