### PR TITLE
Allow Open File on Remote with no line number

### DIFF
--- a/src/commands/openFileInRemote.ts
+++ b/src/commands/openFileInRemote.ts
@@ -60,7 +60,10 @@ export class OpenFileInRemoteCommand extends ActiveEditorCommand {
 		try {
 			const remotes = await Container.git.getRemotes(gitUri.repoPath);
 			const range =
-				args.range && editor != null && UriComparer.equals(editor.document.uri, uri)
+				args.range &&
+				editor != null &&
+				UriComparer.equals(editor.document.uri, uri) &&
+				!editor.selection.start.isEqual(editor.selection.end)
 					? new Range(
 							editor.selection.start.with({ line: editor.selection.start.line + 1 }),
 							editor.selection.end.with({ line: editor.selection.end.line + 1 })


### PR DESCRIPTION
Only assign a line number when opening a file on remote if there is a selection.

Fixes #903

# Description

This change allows a file to be opened on remote with no line selected. If you would like to select just one line, you just have to make any selection in the editor on that line. Multiline selections are unaffected.

# Checklist

- [✅] I have followed the guidelines in the Contributing document
- [✅] My changes are based off of the `develop` branch
- [✅] My changes follow the coding style of this project
- [✅] My changes build without any errors or warnings
- [✅] My changes have been formatted and linted
- [✅] My changes include any required corresponding changes to the documentation
- [✅] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [✅] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
