### PR TITLE
Sorts origin to top when selecting remotes

### DIFF
--- a/src/git/models/remote.ts
+++ b/src/git/models/remote.ts
@@ -17,6 +17,7 @@ export class GitRemote {
 		return remotes.sort(
 			(a, b) =>
 				(a.default ? -1 : 1) - (b.default ? -1 : 1) ||
+				(a.name === 'origin' ? -1 : 0) ||
 				a.name.localeCompare(b.name, undefined, { numeric: true, sensitivity: 'base' })
 		);
 	}

--- a/src/quickpicks/remotesQuickPick.ts
+++ b/src/quickpicks/remotesQuickPick.ts
@@ -150,7 +150,10 @@ export class RemotesQuickPick {
 		clipboard?: boolean,
 		goBackCommand?: CommandQuickPickItem
 	): Promise<OpenRemoteCommandQuickPickItem | CommandQuickPickItem | undefined> {
-		const items = remotes.map(r => new OpenRemoteCommandQuickPickItem(r, resource, clipboard)) as (
+		const items = remotes
+			// show the origin as the top, 'default' pick
+			.sort(r => (r.name === 'origin' ? -1 : 0))
+			.map(r => new OpenRemoteCommandQuickPickItem(r, resource, clipboard)) as (
 			| OpenRemoteCommandQuickPickItem
 			| CommandQuickPickItem
 		)[];

--- a/src/quickpicks/remotesQuickPick.ts
+++ b/src/quickpicks/remotesQuickPick.ts
@@ -150,10 +150,7 @@ export class RemotesQuickPick {
 		clipboard?: boolean,
 		goBackCommand?: CommandQuickPickItem
 	): Promise<OpenRemoteCommandQuickPickItem | CommandQuickPickItem | undefined> {
-		const items = remotes
-			// show the origin as the top, 'default' pick
-			.sort(r => (r.name === 'origin' ? -1 : 0))
-			.map(r => new OpenRemoteCommandQuickPickItem(r, resource, clipboard)) as (
+		const items = remotes.map(r => new OpenRemoteCommandQuickPickItem(r, resource, clipboard)) as (
 			| OpenRemoteCommandQuickPickItem
 			| CommandQuickPickItem
 		)[];


### PR DESCRIPTION
# Description

Usually I want to, for instance, copy the URL to a commit on the origin, even if I have other remotes from forks. This adds a sort to show the origin at the top of the remotes list by default.

![image](https://user-images.githubusercontent.com/2230985/70817465-7ab92a80-1d86-11ea-8fde-8428482319fd.png)


# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes are based off of the `develop` branch
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
