### PR TITLE
Fix typo in contributing search tag link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Please note the [Code of Conduct](CODE_OF_CONDUCT.md) document, please follow it
 
 ## Your First Code Contribution
 
-Unsure where to begin contributing? You can start by looking through the [`help-wanted`](https://github.com/eamodio/vscode-gitlens/labels/help%20wanted) issues.
+Unsure where to begin contributing? You can start by looking through the [`help-wanted`](https://github.com/eamodio/vscode-gitlens/labels/help-wanted) issues.
 
 ### Getting the code
 


### PR DESCRIPTION
# Description

Fixes link typo in contributing page (would lead to no issues, corrected to the correct issue tag).

# Checklist

<!-- Please check off the following -->

- [X] I have followed the guidelines in the Contributing document
- [X] My changes are based off of the `develop` branch
- [X] My changes follow the coding style of this project
- [X] My changes build without any errors or warnings
- [X] My changes have been formatted and linted
- [X] My changes include any required corresponding changes to the documentation
- [X] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [X] My changes have a descriptive commit message with a short title
