### PR TITLE
Move CodeQL workflow file

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,9 +22,8 @@ jobs:
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1
-      # Override language selection by uncommenting this and choosing your languages
-      # with:
-      #   languages: go, javascript, csharp, python, cpp, java
+      with:
+        languages: javascript
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below).


### PR DESCRIPTION
https://github.com/eamodio/vscode-gitlens/pull/1013 put the CodeQL workflow in a nested directory, which means it doesn't run. This moves it to the top level on the `.github/workflows` directory, which will get it working.