### PR TITLE
Adds ''--textconv' to show to support .gitattributes.

### DIFF
--- a/src/git/git.ts
+++ b/src/git/git.ts
@@ -1101,7 +1101,7 @@ export namespace Git {
 		const args = ref.endsWith(':') ? `${ref}./${file}` : `${ref}:./${file}`;
 
 		try {
-			const data = await git<TOut>(opts, 'show', args, '--');
+			const data = await git<TOut>(opts, 'show', '--textconv', args, '--');
 			return data;
 		} catch (ex) {
 			const msg: string = ex?.toString() ?? '';


### PR DESCRIPTION
# Description

This is a PR for issue #866.

Modifies the `git show` command to add the `--textconv` flag. This allows Gitlens to be used with any file that needs to be ran through `.gitattributes` to make it usable.

Our main motivation is to be able to use gitlens with files encrypted by [git-crypt](https://github.com/AGWA/git-crypt) but this is a generic change that should work with any tools requiring `.gitattributes` usage.

# Checklist

- [X] I have followed the guidelines in the Contributing document
- [X] My changes are based off of the `develop` branch
- [X] My changes follow the coding style of this project
- [X] My changes build without any errors or warnings
- [X] My changes have been formatted and linted
- [X] My changes include any required corresponding changes to the documentation
- [X] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [X] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
