### PR TITLE
Fixed: #969 - Adds feature: Copy relative path to context menu.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2502,6 +2502,15 @@
 				}
 			},
 			{
+				"command": "gitlens.copyRelativePathToClipboard",
+				"title": "Copy Relative Path",
+				"category": "GitLens",
+				"icon": {
+					"dark": "images/dark/icon-copy.svg",
+					"light": "images/light/icon-copy.svg"
+				}
+			},
+			{
 				"command": "gitlens.closeUnchangedFiles",
 				"title": "Close Unchanged Files",
 				"category": "GitLens"
@@ -3668,6 +3677,10 @@
 					"when": "gitlens:activeFileStatus =~ /blameable/"
 				},
 				{
+					"command": "gitlens.copyRelativePathToClipboard",
+					"when": "gitlens:enabled"
+				},
+				{
 					"command": "gitlens.closeUnchangedFiles",
 					"when": "gitlens:enabled"
 				},
@@ -4320,6 +4333,11 @@
 					"command": "gitlens.copyRemoteFileUrlToClipboard",
 					"when": "editorTextFocus && gitlens:activeFileStatus =~ /remotes/ && config.gitlens.menus.editor.clipboard",
 					"group": "9_cutcopypaste_gitlens@4"
+				},
+				{
+					"command": "gitlens.copyRelativePathToClipboard",
+					"when": "editorTextFocus && gitlens:activeFileStatus =~ /blameable/ && config.gitlens.menus.editor.clipboard",
+					"group": "9_cutcopypaste_gitlens@5"
 				}
 			],
 			"editor/title": [

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -8,6 +8,7 @@ export * from './commands/copyMessageToClipboard';
 export * from './commands/copyRemoteCommitUrlToClipboard';
 export * from './commands/copyRemoteFileUrlToClipboard';
 export * from './commands/copyShaToClipboard';
+export * from './commands/copyRelativePathToClipboard';
 export * from './commands/diffBranchWith';
 export * from './commands/openDirectoryCompare';
 export * from './commands/diffLineWithPrevious';

--- a/src/commands/common.ts
+++ b/src/commands/common.ts
@@ -34,7 +34,11 @@ export enum Commands {
 	CopyMessageToClipboard = 'gitlens.copyMessageToClipboard',
 	CopyRemoteCommitUrlToClipboard = 'gitlens.copyRemoteCommitUrlToClipboard',
 	CopyRemoteFileUrlToClipboard = 'gitlens.copyRemoteFileUrlToClipboard',
+
 	CopyShaToClipboard = 'gitlens.copyShaToClipboard',
+
+	CopyRelativePathToClipboard = 'gitlens.copyRelativePathToClipboard',
+
 	DiffDirectory = 'gitlens.diffDirectory',
 	DiffDirectoryWithHead = 'gitlens.diffDirectoryWithHead',
 	DiffHeadWith = 'gitlens.diffHeadWith',

--- a/src/commands/copyRelativePathToClipboard.ts
+++ b/src/commands/copyRelativePathToClipboard.ts
@@ -1,0 +1,24 @@
+'use strict';
+import { env, TextEditor, Uri } from 'vscode';
+import { ActiveEditorCommand, command, Commands, getCommandUri } from './common';
+import { Container } from '../container';
+
+@command()
+export class CopyRelativePathCommand extends ActiveEditorCommand {
+	constructor() {
+		super(Commands.CopyRelativePathToClipboard);
+	}
+	async execute(editor?: TextEditor, uri?: Uri) {
+		uri = getCommandUri(uri, editor);
+		const repoPath = await Container.git.getActiveRepoPath(editor);
+		let relativePath = '';
+		if (uri != null && repoPath != null) {
+			const pathSplit = uri.path.split(repoPath);
+			if (pathSplit.length > 0) {
+				relativePath = pathSplit[pathSplit.length - 1];
+			}
+		}
+		void (await env.clipboard.writeText(relativePath));
+		return undefined;
+	}
+}


### PR DESCRIPTION
Add feature: Show copy relative path to contextual menu.

Fixes #969 

# Description
Created the command execute file on 
    - src/commands/copyRelativePathToClipboard.ts
Added it to the commons on
    - src/commands/common.ts
    - src/commands.ts
Added the command to the context menu on the package.json file.

# Checklist

- [x] I have followed the guidelines in the Contributing document
- [x] My changes are based off of the `develop` branch
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [ ] My changes include any required corresponding changes to the documentation
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
