### PR TITLE
Fixes #1072 - Add whitespace to tree item tooltip

### DIFF
--- a/src/views/nodes/branchTrackingStatusNode.ts
+++ b/src/views/nodes/branchTrackingStatusNode.ts
@@ -113,7 +113,7 @@ export class BranchTrackingStatusNode extends ViewNode<ViewWithFiles> implements
 				: ResourceType.BranchStatusBehindUpstream;
 		}
 		item.iconPath = new ThemeIcon(ahead ? 'cloud-upload' : 'cloud-download');
-		item.tooltip = `${label}${ahead ? ' of ' : ''}${this.status.upstream}`;
+		item.tooltip = `${label}${ahead ? ' of ' : ' '}${this.status.upstream}`;
 		return item;
 	}
 


### PR DESCRIPTION
# Description

Adds missing whitespace in a branch "n commits behind" item tooltip.

Fixes #1072.

Before:
![image](https://user-images.githubusercontent.com/12111013/87372138-29964100-c5ca-11ea-8157-0c757fc5d5e7.png)

After:
![image](https://user-images.githubusercontent.com/12111013/87372033-f94ea280-c5c9-11ea-94e9-b30b7afbd28d.png)

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes are based off of the `develop` branch
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation
- [ ] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
