### PR TITLE
Closes #921 - hides sidebar icon if no git repos are open

### DIFF
--- a/package.json
+++ b/package.json
@@ -6052,35 +6052,35 @@
 				{
 					"id": "gitlens.views.repositories:gitlens",
 					"name": "Repositories",
-					"when": "config.gitlens.views.repositories.enabled && config.gitlens.views.repositories.location == gitlens",
+					"when": "config.git.enabled && gitOpenRepositoryCount != 0 && config.gitlens.views.repositories.enabled && config.gitlens.views.repositories.location == gitlens",
 					"contextualTitle": "GitLens",
 					"icon": "images/views/repositories.svg"
 				},
 				{
 					"id": "gitlens.views.fileHistory:gitlens",
 					"name": "File History",
-					"when": "config.gitlens.views.fileHistory.enabled && config.gitlens.views.fileHistory.location == gitlens",
+					"when": "config.git.enabled && gitOpenRepositoryCount != 0 && config.gitlens.views.fileHistory.enabled && config.gitlens.views.fileHistory.location == gitlens",
 					"contextualTitle": "GitLens",
 					"icon": "images/views/history.svg"
 				},
 				{
 					"id": "gitlens.views.lineHistory:gitlens",
 					"name": "Line History",
-					"when": "config.gitlens.views.lineHistory.enabled && config.gitlens.views.lineHistory.location == gitlens",
+					"when": "config.git.enabled && gitOpenRepositoryCount != 0 && config.gitlens.views.lineHistory.enabled && config.gitlens.views.lineHistory.location == gitlens",
 					"contextualTitle": "GitLens",
 					"icon": "images/views/history.svg"
 				},
 				{
 					"id": "gitlens.views.compare:gitlens",
 					"name": "Compare Commits",
-					"when": "config.gitlens.views.compare.enabled && config.gitlens.views.compare.location == gitlens",
+					"when": "config.git.enabled && gitOpenRepositoryCount != 0 && config.gitlens.views.compare.enabled && config.gitlens.views.compare.location == gitlens",
 					"contextualTitle": "GitLens",
 					"icon": "images/views/compare.svg"
 				},
 				{
 					"id": "gitlens.views.search:gitlens",
 					"name": "Search Commits",
-					"when": "config.gitlens.views.search.enabled && config.gitlens.views.search.location == gitlens",
+					"when": "config.git.enabled && gitOpenRepositoryCount != 0 && config.gitlens.views.search.enabled && config.gitlens.views.search.location == gitlens",
 					"contextualTitle": "GitLens",
 					"icon": "images/views/search.svg"
 				}
@@ -6089,35 +6089,35 @@
 				{
 					"id": "gitlens.views.repositories:explorer",
 					"name": "Repositories",
-					"when": "gitlens:enabled && config.gitlens.views.repositories.enabled && config.gitlens.views.repositories.location == explorer",
+					"when": "config.git.enabled && gitOpenRepositoryCount != 0 && gitlens:enabled && config.gitlens.views.repositories.enabled && config.gitlens.views.repositories.location == explorer",
 					"contextualTitle": "GitLens",
 					"icon": "images/views/repositories.svg"
 				},
 				{
 					"id": "gitlens.views.fileHistory:explorer",
 					"name": "File History",
-					"when": "gitlens:enabled && config.gitlens.views.fileHistory.enabled && config.gitlens.views.fileHistory.location == explorer",
+					"when": "config.git.enabled && gitOpenRepositoryCount != 0 && gitlens:enabled && config.gitlens.views.fileHistory.enabled && config.gitlens.views.fileHistory.location == explorer",
 					"contextualTitle": "GitLens",
 					"icon": "images/views/history.svg"
 				},
 				{
 					"id": "gitlens.views.lineHistory:explorer",
 					"name": "Line History",
-					"when": "gitlens:enabled && config.gitlens.views.lineHistory.enabled && config.gitlens.views.lineHistory.location == explorer",
+					"when": "config.git.enabled && gitOpenRepositoryCount != 0 && gitlens:enabled && config.gitlens.views.lineHistory.enabled && config.gitlens.views.lineHistory.location == explorer",
 					"contextualTitle": "GitLens",
 					"icon": "images/views/history.svg"
 				},
 				{
 					"id": "gitlens.views.compare:explorer",
 					"name": "Compare Commits",
-					"when": "gitlens:enabled && config.gitlens.views.compare.enabled && config.gitlens.views.compare.location == explorer",
+					"when": "config.git.enabled && gitOpenRepositoryCount != 0 && gitlens:enabled && config.gitlens.views.compare.enabled && config.gitlens.views.compare.location == explorer",
 					"contextualTitle": "GitLens",
 					"icon": "images/views/compare.svg"
 				},
 				{
 					"id": "gitlens.views.search:explorer",
 					"name": "Search Commits",
-					"when": "gitlens:enabled && config.gitlens.views.search.enabled && config.gitlens.views.search.location == explorer",
+					"when": "config.git.enabled && gitOpenRepositoryCount != 0 && gitlens:enabled && config.gitlens.views.search.enabled && config.gitlens.views.search.location == explorer",
 					"contextualTitle": "GitLens",
 					"icon": "images/views/search.svg"
 				}
@@ -6126,35 +6126,35 @@
 				{
 					"id": "gitlens.views.repositories:scm",
 					"name": "Repositories",
-					"when": "gitlens:enabled && config.gitlens.views.repositories.enabled && config.gitlens.views.repositories.location == scm",
+					"when": "config.git.enabled && gitOpenRepositoryCount != 0 && gitlens:enabled && config.gitlens.views.repositories.enabled && config.gitlens.views.repositories.location == scm",
 					"contextualTitle": "GitLens",
 					"icon": "images/views/repositories.svg"
 				},
 				{
 					"id": "gitlens.views.fileHistory:scm",
 					"name": "File History",
-					"when": "gitlens:enabled && config.gitlens.views.fileHistory.enabled && config.gitlens.views.fileHistory.location == scm",
+					"when": "config.git.enabled && gitOpenRepositoryCount != 0 && gitlens:enabled && config.gitlens.views.fileHistory.enabled && config.gitlens.views.fileHistory.location == scm",
 					"contextualTitle": "GitLens",
 					"icon": "images/views/history.svg"
 				},
 				{
 					"id": "gitlens.views.lineHistory:scm",
 					"name": "Line History",
-					"when": "gitlens:enabled && config.gitlens.views.lineHistory.enabled && config.gitlens.views.lineHistory.location == scm",
+					"when": "config.git.enabled && gitOpenRepositoryCount != 0 && gitlens:enabled && config.gitlens.views.lineHistory.enabled && config.gitlens.views.lineHistory.location == scm",
 					"contextualTitle": "GitLens",
 					"icon": "images/views/history.svg"
 				},
 				{
 					"id": "gitlens.views.compare:scm",
 					"name": "Compare Commits",
-					"when": "gitlens:enabled && config.gitlens.views.compare.enabled && config.gitlens.views.compare.location == scm",
+					"when": "config.git.enabled && gitOpenRepositoryCount != 0 && gitlens:enabled && config.gitlens.views.compare.enabled && config.gitlens.views.compare.location == scm",
 					"contextualTitle": "GitLens",
 					"icon": "images/views/compare.svg"
 				},
 				{
 					"id": "gitlens.views.search:scm",
 					"name": "Search Commits",
-					"when": "gitlens:enabled && config.gitlens.views.search.enabled && config.gitlens.views.search.location == scm",
+					"when": "config.git.enabled && gitOpenRepositoryCount != 0 && gitlens:enabled && config.gitlens.views.search.enabled && config.gitlens.views.search.location == scm",
 					"contextualTitle": "GitLens",
 					"icon": "images/views/search.svg"
 				}


### PR DESCRIPTION
# Description

Closes #921- hides sidebar icon if no git repos are open

- hides GitLens sidebar icon if no git repos are open
- I don't think there are any documentation updates needed (couldn't find any references to sidebar icon in the docs), maybe this would go into release notes later?

![hide-icon-2](https://user-images.githubusercontent.com/25670682/87867317-11d50900-c98c-11ea-8d36-d28b50acad36.gif)

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes are based off of the `develop` branch
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
