### PR TITLE
Closes #1165 - Adds options to modify file annotation button behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -835,6 +835,12 @@ See also [View Settings](#view-settings- 'Jump to the View settings')
 | `gitlens.heatmap.hotColor`     | Specifies the base color of the gutter heatmap annotations when the most recent change is newer (hot) than the `gitlens.heatmap.ageThreshold` value                                                             |
 | `gitlens.heatmap.toggleMode`   | Specifies how the gutter heatmap annotations will be toggled<br /><br />`file` - toggles each file individually<br />`window` - toggles the window, i.e. all files at once                                      |
 
+## File Annotations Settings [#](#file-annotation-settings- 'File Changes Settings')
+
+| Name                           | Description                                                                                                                                                                                                     |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `gitlens.fileAnnotations.command` | Specifies whether the file annotations button in the editor title toggles blame, heatmap, or change annotations. Setting this to `null` (default) makes the button act as a menu |
+
 ## Git Command Palette Settings [#](#git-command-palette-settings- 'Git Command Palette Settings')
 
 | Name                                              | Description                                                                                                                           |
@@ -857,11 +863,9 @@ See also [View Settings](#view-settings- 'Jump to the View settings')
 
 ## Menu & Toolbar Settings [#](#menu--toolbar-settings- 'Menu & Toolbar Settings')
 
-| Name                                   | Description                                                                                                          |
-| -------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `gitlens.menus`                        | Specifies which commands will be added to which menus                                                                |
-| `gitlens.menus.annotations.behaviour`  | Specifies whether the file annotations button in the editor title acts as a menu (default) or a toggle button        |
-| `gitlens.menus.annotations.toggleType` | Specifies whether the file annotations button toggles file blame, heatmap or changes (if behaviour is set to toggle) |
+| Name            | Description                                           |
+| --------------- | ----------------------------------------------------- |
+| `gitlens.menus` | Specifies which commands will be added to which menus |
 
 ## Keyboard Shortcut Settings [#](#keyboard-shortcut-settings- 'Keyboard Shortcut Settings')
 

--- a/README.md
+++ b/README.md
@@ -857,9 +857,11 @@ See also [View Settings](#view-settings- 'Jump to the View settings')
 
 ## Menu & Toolbar Settings [#](#menu--toolbar-settings- 'Menu & Toolbar Settings')
 
-| Name            | Description                                           |
-| --------------- | ----------------------------------------------------- |
-| `gitlens.menus` | Specifies which commands will be added to which menus |
+| Name                                   | Description                                                                                                          |
+| -------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `gitlens.menus`                        | Specifies which commands will be added to which menus                                                                |
+| `gitlens.menus.annotations.behaviour`  | Specifies whether the file annotations button in the editor title acts as a menu (default) or a toggle button        |
+| `gitlens.menus.annotations.toggleType` | Specifies whether the file annotations button toggles file blame, heatmap or changes (if behaviour is set to toggle) |
 
 ## Keyboard Shortcut Settings [#](#keyboard-shortcut-settings- 'Keyboard Shortcut Settings')
 

--- a/package.json
+++ b/package.json
@@ -708,6 +708,25 @@
 					"markdownDescription": "Specifies which (and when) Git commands will skip the confirmation step, using the format: `git-command-name:(menu|command)`",
 					"scope": "window"
 				},
+				"gitlens.fileAnnotations.command": {
+					"type": [
+						"string",
+						"null"
+					],
+					"default": null,
+					"enum": [
+						"blame",
+						"heatmap",
+						"changes"
+					],
+					"enumDescriptions": [
+						"Toggles file blame annotations",
+						"Toggles file heatmap annotations",
+						"Toggles file changes annotations"
+					],
+					"markdownDescription": "Specifies what the file annotations button in the editor title toggles. Setting this to null makes the button act as a menu",
+					"scope": "window"
+				},
 				"gitlens.heatmap.ageThreshold": {
 					"type": "number",
 					"default": 90,
@@ -1132,36 +1151,6 @@
 						}
 					},
 					"markdownDescription": "Specifies which commands will be added to which menus",
-					"scope": "window"
-				},
-				"gitlens.menus.annotations.behaviour": {
-					"type": "string",
-					"default": "menu",
-					"enum": [
-						"menu",
-						"toggle"
-					],
-					"enumDescriptions": [
-						"Clicking the button opens up a menu with toggle options",
-						"Clicking the button toggles blame (default), heatmap or changes"
-					],
-					"markdownDescription": "Specifies whether the file annotations button in the editor title acts as a menu (default) or a toggle button",
-					"scope": "window"
-				},
-				"gitlens.menus.annotations.toggleType": {
-					"type": "string",
-					"default": "blame",
-					"enum": [
-						"blame",
-						"heatmap",
-						"changes"
-					],
-					"enumDescriptions": [
-						"Toggles file blame annotations",
-						"Toggles file heatmap annotations",
-						"Toggles file changes annotations"
-					],
-					"markdownDescription": "Specifies whether the file annotations button toggles file blame, heatmap or changes (if behaviour is set to toggle)",
 					"scope": "window"
 				},
 				"gitlens.mode.active": {
@@ -5695,22 +5684,22 @@
 				},
 				{
 					"command": "gitlens.toggleFileBlame",
-					"when": "config.gitlens.menus.annotations.behaviour == toggle && config.gitlens.menus.annotations.toggleType == blame && gitlens:activeFileStatus =~ /blameable/ && !gitlens:annotationStatus && config.gitlens.menus.editorGroup.blame",
+					"when": "config.gitlens.fileAnnotations.command == blame && gitlens:activeFileStatus =~ /blameable/ && !gitlens:annotationStatus && config.gitlens.menus.editorGroup.blame",
 					"group": "navigation@100"
 				},
 				{
 					"command": "gitlens.toggleFileHeatmap",
-					"when": "config.gitlens.menus.annotations.behaviour == toggle && config.gitlens.menus.annotations.toggleType == heatmap && gitlens:activeFileStatus =~ /blameable/ && !gitlens:annotationStatus && config.gitlens.menus.editorGroup.blame",
+					"when": "config.gitlens.fileAnnotations.command == heatmap && gitlens:activeFileStatus =~ /blameable/ && !gitlens:annotationStatus && config.gitlens.menus.editorGroup.blame",
 					"group": "navigation@100"
 				},
 				{
 					"command": "gitlens.toggleFileChanges",
-					"when": "config.gitlens.menus.annotations.behaviour == toggle && config.gitlens.menus.annotations.toggleType == changes && gitlens:activeFileStatus =~ /blameable/ && !gitlens:annotationStatus && config.gitlens.menus.editorGroup.blame",
+					"when": "config.gitlens.fileAnnotations.command == changes && gitlens:activeFileStatus =~ /blameable/ && !gitlens:annotationStatus && config.gitlens.menus.editorGroup.blame",
 					"group": "navigation@100"
 				},
 				{
 					"submenu": "gitlens/editor/annotations",
-					"when": "config.gitlens.menus.annotations.behaviour == menu && gitlens:activeFileStatus =~ /blameable/ && !gitlens:annotationStatus && config.gitlens.menus.editorGroup.blame",
+					"when": "!config.gitlens.fileAnnotations.command && gitlens:activeFileStatus =~ /blameable/ && !gitlens:annotationStatus && config.gitlens.menus.editorGroup.blame",
 					"group": "navigation@100"
 				},
 				{

--- a/package.json
+++ b/package.json
@@ -1134,6 +1134,36 @@
 					"markdownDescription": "Specifies which commands will be added to which menus",
 					"scope": "window"
 				},
+				"gitlens.menus.annotations.behaviour": {
+					"type": "string",
+					"default": "menu",
+					"enum": [
+						"menu",
+						"toggle"
+					],
+					"enumDescriptions": [
+						"Clicking the button opens up a menu with toggle options",
+						"Clicking the button toggles blame (default), heatmap or changes"
+					],
+					"markdownDescription": "Specifies whether the file annotations button in the editor title acts as a menu (default) or a toggle button",
+					"scope": "window"
+				},
+				"gitlens.menus.annotations.toggleType": {
+					"type": "string",
+					"default": "blame",
+					"enum": [
+						"blame",
+						"heatmap",
+						"changes"
+					],
+					"enumDescriptions": [
+						"Toggles file blame annotations",
+						"Toggles file heatmap annotations",
+						"Toggles file changes annotations"
+					],
+					"markdownDescription": "Specifies whether the file annotations button toggles file blame, heatmap or changes (if behaviour is set to toggle)",
+					"scope": "window"
+				},
 				"gitlens.mode.active": {
 					"type": "string",
 					"markdownDescription": "Specifies the active GitLens mode, if any",
@@ -5664,8 +5694,23 @@
 					"group": "navigation@99"
 				},
 				{
+					"command": "gitlens.toggleFileBlame",
+					"when": "config.gitlens.menus.annotations.behaviour == toggle && config.gitlens.menus.annotations.toggleType == blame && gitlens:activeFileStatus =~ /blameable/ && !gitlens:annotationStatus && config.gitlens.menus.editorGroup.blame",
+					"group": "navigation@100"
+				},
+				{
+					"command": "gitlens.toggleFileHeatmap",
+					"when": "config.gitlens.menus.annotations.behaviour == toggle && config.gitlens.menus.annotations.toggleType == heatmap && gitlens:activeFileStatus =~ /blameable/ && !gitlens:annotationStatus && config.gitlens.menus.editorGroup.blame",
+					"group": "navigation@100"
+				},
+				{
+					"command": "gitlens.toggleFileChanges",
+					"when": "config.gitlens.menus.annotations.behaviour == toggle && config.gitlens.menus.annotations.toggleType == changes && gitlens:activeFileStatus =~ /blameable/ && !gitlens:annotationStatus && config.gitlens.menus.editorGroup.blame",
+					"group": "navigation@100"
+				},
+				{
 					"submenu": "gitlens/editor/annotations",
-					"when": "gitlens:activeFileStatus =~ /blameable/ && !gitlens:annotationStatus && config.gitlens.menus.editorGroup.blame",
+					"when": "config.gitlens.menus.annotations.behaviour == menu && gitlens:activeFileStatus =~ /blameable/ && !gitlens:annotationStatus && config.gitlens.menus.editorGroup.blame",
 					"group": "navigation@100"
 				},
 				{

--- a/src/config.ts
+++ b/src/config.ts
@@ -56,6 +56,9 @@ export interface Config {
 		};
 		skipConfirmations: string[];
 	};
+	fileAnnotations: {
+		command: string | null;
+	};
 	heatmap: {
 		ageThreshold: number;
 		coldColor: string;


### PR DESCRIPTION
# Description

Adds two options to modify the behaviour of the file annotations button:
- "gitlens.menus.annotations.behaviour" changes the behaviour between a menu (default) and a toggle button
- "gitlens.menus.annotations.toggleType" changes what is toggled when behaviour is set to toggle

I wasn't too sure of what to name the settings so if you can suggest more appropriate ones that would be great.

# Checklist

<!-- Please check off the following -->

- [X] I have followed the guidelines in the Contributing document
- [X] My changes follow the coding style of this project
- [X] My changes build without any errors or warnings
- [X] My changes have been formatted and linted
- [X] My changes include any required corresponding changes to the documentation
- [X] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [X] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
