### PR TITLE
Fixes #1187 - adds missing escape in regexp

### DIFF
--- a/package.json
+++ b/package.json
@@ -6816,12 +6816,12 @@
 				},
 				{
 					"command": "gitlens.showCommitInView",
-					"when": "viewItem =~ /gitlens:file\\b(?!(+stashed|:status))/",
+					"when": "viewItem =~ /gitlens:file\\b(?!(\\+stashed|:status))/",
 					"group": "3_gitlens_explore@3"
 				},
 				{
 					"command": "gitlens.revealCommitInView",
-					"when": "viewItem =~ /gitlens:file\\b(?!(+stashed|:status))/",
+					"when": "viewItem =~ /gitlens:file\\b(?!(\\+stashed|:status))/",
 					"group": "3_gitlens_explore@4"
 				},
 				{


### PR DESCRIPTION
# Description

Fixes regexp that causes warning. Checked other regexps in `package.json` and haven't found problems with them.

# Checklist

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
