### PR TITLE
Fixes #1045 - Take UNC path from query instead of uri

### DIFF
--- a/src/git/gitUri.ts
+++ b/src/git/gitUri.ts
@@ -65,7 +65,7 @@ export class GitUri extends ((Uri as any) as UriEx) {
 			super({
 				scheme: uri.scheme,
 				authority: uri.authority,
-				path: uri.path,
+				path: data.path,
 				query: JSON.stringify(data),
 				fragment: uri.fragment,
 			});

--- a/src/git/gitUri.ts
+++ b/src/git/gitUri.ts
@@ -56,10 +56,15 @@ export class GitUri extends ((Uri as any) as UriEx) {
 		if (uri.scheme === DocumentSchemes.GitLens) {
 			const data = JSON.parse(uri.query) as UriRevisionData;
 
-			// When Uri's come from the FileSystemProvider, the uri.query only contains the root repo info (not the actual file path), so fix that here
-			const index = uri.path.indexOf(data.path);
-			if (index + data.path.length < uri.path.length) {
-				data.path = index === 0 ? uri.path : uri.path.substr(index);
+			// Fixes issues with uri.query:
+			// When Uri's come from the FileSystemProvider, the uri.query only contains the root repo info (not the actual file path)
+			// When Uri's come from breadcrumbs (via the FileSystemProvider), the uri.query contains the wrong file path
+			if (data.path !== uri.path) {
+				if (data.path.startsWith('//') && !uri.path.startsWith('//')) {
+					data.path = `/${uri.path}`;
+				} else {
+					data.path = uri.path;
+				}
 			}
 
 			super({


### PR DESCRIPTION
# Description

When UNC path is used for a repo the gitUri is formatted without the double slash.

The following example is from a repo on `//aesrocc/home/ROCCTEST`
```
gitlens://0cee44d/aesrocc/home/ROCCTEST/fldedit/invfe53gst.et?{"path":"//aesrocc/home/ROCCTEST/fldedit/invfe53gst.et","ref":"0cee44d88243c4180f17837d9adf3b43a231ead2","repoPath":"//aesrocc/home/ROCCTEST"}
\_____/   \_____/\__________________________________________/ \___________________________________________________________________________________________________________________________________________/ 
   |        |            |                                                                                 |
scheme     authority       path                                                                 query   
```

The uri strips the `//`

`uri.path = /aesrocc/home/ROCCTEST/fldedit/invfe53gst.et`

but the path is still correct in the `path` element  of the query string and should be reliable on all file systems

`data.path = //aesrocc/home/ROCCTEST/fldedit/invfe53gst.et` (from query)

# Checklist

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
