### PR TITLE
Fix url that redirect to the "connect to remote provider" documentation

### DIFF
--- a/src/quickpicks/remoteProviderPicker.ts
+++ b/src/quickpicks/remoteProviderPicker.ts
@@ -19,7 +19,7 @@ export class ConfigureCustomRemoteProviderCommandQuickPickItem extends CommandQu
 	}
 
 	async execute(): Promise<void> {
-		await env.openExternal(Uri.parse('https://github.com/eamodio/vscode-gitlens#custom-remotes-settings'));
+		await env.openExternal(Uri.parse('https://github.com/eamodio/vscode-gitlens#remote-provider-integration-settings-'));
 	}
 }
 


### PR DESCRIPTION
- GitLens Version: 11.1.0

# Description
Fix the url linked to the `gitlens.connectRemoteProvider` command.

![image](https://user-images.githubusercontent.com/8977909/103317928-9d1af600-4a24-11eb-841f-3b396087beac.png)

So, clicking on the help link now will redirect and navigate to the anchor text (here [Remote Provider Integration Settings](https://github.com/eamodio/vscode-gitlens#remote-provider-integration-settings-) )

# Checklist

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
