### PR TITLE
Fixes #1303: Fix remote URLs for Azure DevOps

### DIFF
--- a/src/git/remotes/azure-devops.ts
+++ b/src/git/remotes/azure-devops.ts
@@ -35,6 +35,10 @@ export class AzureDevOpsRemote extends RemoteProvider {
 			}
 		}
 
+		// Azure DevOps allows projects and repository names with spaces. In that situation,
+		// the `path` will be previously encoded during git clone
+		// revert that encoding to avoid double-encoding by gitlens during copy remote and open remote
+		path = decodeURIComponent(path);
 		super(domain, path, protocol, name);
 	}
 
@@ -131,8 +135,8 @@ export class AzureDevOpsRemote extends RemoteProvider {
 			line = '';
 		}
 
-		if (sha) return `${this.baseUrl}/commit/${sha}/?_a=contents&path=%2F${fileName}${line}`;
-		if (branch) return `${this.baseUrl}/?path=%2F${fileName}&version=GB${branch}&_a=contents${line}`;
-		return `${this.baseUrl}?path=%2F${fileName}${line}`;
+		if (sha) return `${this.baseUrl}/commit/${sha}/?_a=contents&path=/${fileName}${line}`;
+		if (branch) return `${this.baseUrl}/?path=/${fileName}&version=GB${branch}&_a=contents${line}`;
+		return `${this.baseUrl}?path=/${fileName}${line}`;
 	}
 }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the changes and which issue will be addressed. Please also include relevant motivation and context.
-->

Fixes #1303 

Remove the encoding to prevent double encoding for Azure DevOps URLs, to avoid these URLs from being 404 URLs.

# Backstory:
When we added encodeURI() wrappers in 545dc4aac1a745362cabc6ed808d7c608dbe4a34, this caused a double-encoding problem with Azure DevOps URLs.


The problem exists in two places:

1. The baseUrl. Azure DevOps allows us to create projects and repositories which include spaces. This results in the path (and the subsequent baseUrl) containing `%20`. After being run through encodeURI(), this was changed to `%2520` which resulted in a 404.
    1. I've decoded the path, so that later down the workflow, when we encode the entire URL, we don't end up double-encoding
---

2. The file path. Azure DevOps deep links to a path were hard-coded to use `%2F` instead of the `/`. After being run through encodeURI(), these were being changed to `%252F`, again resulting in a 404
    1. I changed this back to `/`. After passing through encodeURI, this remains untouched as `/` which works fine with Azure DevOps.


# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses