### PR TITLE
Adds Feature for Copy Current Branch Name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Adds the _Add Remote_ command to the branch status in the _Branches_, _Commits_, and _Repositories_ views when there are no Git remotes configured
 - Adds a new _Browse Repository from Before Here_ (`gitlens.browseRepoBeforeRevision`) and _Browse Repository from Before Here in New Window_ (`gitlens.browseRepoBeforeRevisionInNewWindow`) commands
 - Adds _Repository from Before Here_ and _Repository from Before Here in New Window_ to the _Browse_ submenu of commits in the views
+- Adds a new _Copy Current Branch Name_ (`gitlens.copyCurrentBranch`) command to copy the current branch name to the clipboard &mdash; closes [#1306](https://github.com/eamodio/vscode-gitlens/issues/1306) &mdash; thanks to [PR #1307](https://github.com/eamodio/vscode-gitlens/pull/1307) by Ken Hom ([@kh0m](https://github.com/kh0m))
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -1013,6 +1013,7 @@ A big thanks to the people that have contributed to this project:
 - Geoffrey ([@g3offrey](https://github.com/g3offrey)) &mdash; [contributions](https://github.com/eamodio/vscode-gitlens/commits?author=g3offrey)
 - grozan ([@grozan](https://github.com/grozan)) &mdash; [contributions](https://github.com/eamodio/vscode-gitlens/commits?author=grozan)
 - Guillem ([@guillemglez](https://github.com/guillemglez)) &mdash; [contributions](https://github.com/eamodio/vscode-gitlens/commits?author=guillemglez)
+- Ken Hom ([@kh0m](https://github.com/kh0m)) &mdash; [contributions](https://github.com/eamodio/vscode-gitlens/commits?author=kh0m)
 - Yukai Huang ([@Yukaii](https://github.com/Yukaii)) &mdash; [contributions](https://github.com/eamodio/vscode-gitlens/commits?author=Yukaii)
 - Justin Hutchings ([@jhutchings1](https://github.com/jhutchings1)) &mdash; [contributions](https://github.com/eamodio/vscode-gitlens/commits?author=jhutchings1)
 - Roy Ivy III ([@rivy](https://github.com/rivy)) &mdash; [contributions](https://github.com/eamodio/vscode-gitlens/commits?author=rivy)

--- a/README.md
+++ b/README.md
@@ -596,6 +596,8 @@ Additionally, these integrations provide commands to copy the url of or open, fi
 - Adds a _Copy SHA_ command (`gitlens.copyShaToClipboard`) to copy the commit SHA of the current line to the clipboard or from the most recent commit to the current branch, if there is no current editor
 - Adds a _Copy Message_ command (`gitlens.copyMessageToClipboard`) to copy the commit message of the current line to the clipboard or from the most recent commit to the current branch, if there is no current editor
 
+- Adds a _Copy Current Branch_ command (`gitlens.copyCurrentBranch`) to copy the name of the current branch to the clipboard
+
 - Adds a _Switch to Another Branch_ (`gitlens.views.switchToAnotherBranch`) command &mdash; to quickly switch the current branch
 
 - Adds a _Compare References..._ command (`gitlens.compareWith`) to compare two selected references

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
 		"onCommand:gitlens.addAuthors",
 		"onCommand:gitlens.connectRemoteProvider",
 		"onCommand:gitlens.disconnectRemoteProvider",
+		"oncommand:gitlens.copyCurrentBranch",
 		"onCommand:gitlens.copyMessageToClipboard",
 		"onCommand:gitlens.copyShaToClipboard",
 		"onCommand:gitlens.closeUnchangedFiles",
@@ -185,7 +186,6 @@
 		"onCommand:gitlens.fetchRepositories",
 		"onCommand:gitlens.pullRepositories",
 		"onCommand:gitlens.pushRepositories",
-		"oncommand:gitlens.copyCurrentBranch",
 		"onStartupFinished"
 	],
 	"contributes": {
@@ -3186,6 +3186,15 @@
 				"category": "GitLens"
 			},
 			{
+				"command": "gitlens.copyCurrentBranch",
+				"title": "Copy Current Branch Name",
+				"category": "GitLens",
+				"icon": {
+					"dark": "images/dark/icon-copy.svg",
+					"light": "images/light/icon-copy.svg"
+				}
+			},
+			{
 				"command": "gitlens.copyMessageToClipboard",
 				"title": "Copy Message",
 				"category": "GitLens",
@@ -4694,11 +4703,6 @@
 				"command": "gitlens.views.tags.setShowAvatarsOff",
 				"title": "Hide Avatars",
 				"category": "GitLens"
-			},
-			{
-				"command": "gitlens.copyCurrentBranch",
-				"title": "Copy Current Branch",
-				"category": "GitLens"
 			}
 		],
 		"menus": {
@@ -5034,6 +5038,10 @@
 				{
 					"command": "gitlens.resetRemoteConnectionAuthorization",
 					"when": "config.gitlens.integrations.enabled && gitlens:hasRichRemotes"
+				},
+				{
+					"command": "gitlens.copyCurrentBranch",
+					"when": "gitlens:enabled"
 				},
 				{
 					"command": "gitlens.copyMessageToClipboard",

--- a/package.json
+++ b/package.json
@@ -185,6 +185,7 @@
 		"onCommand:gitlens.fetchRepositories",
 		"onCommand:gitlens.pullRepositories",
 		"onCommand:gitlens.pushRepositories",
+		"oncommand:gitlens.copyCurrentBranch",
 		"onStartupFinished"
 	],
 	"contributes": {
@@ -4692,6 +4693,11 @@
 			{
 				"command": "gitlens.views.tags.setShowAvatarsOff",
 				"title": "Hide Avatars",
+				"category": "GitLens"
+			},
+			{
+				"command": "gitlens.copyCurrentBranch",
+				"title": "Copy Current Branch",
 				"category": "GitLens"
 			}
 		],

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -6,6 +6,7 @@ export * from './commands/closeUnchangedFiles';
 export * from './commands/closeView';
 export * from './commands/common';
 export * from './commands/compareWith';
+export * from './commands/copyCurrentBranch';
 export * from './commands/copyMessageToClipboard';
 export * from './commands/copyShaToClipboard';
 export * from './commands/openDirectoryCompare';

--- a/src/commands/common.ts
+++ b/src/commands/common.ts
@@ -41,6 +41,7 @@ export enum Commands {
 	CompareWorkingWith = 'gitlens.compareWorkingWith',
 	ComputingFileAnnotations = 'gitlens.computingFileAnnotations',
 	ConnectRemoteProvider = 'gitlens.connectRemoteProvider',
+	CopyCurrentBranch = 'gitlens.copyCurrentBranch',
 	CopyMessageToClipboard = 'gitlens.copyMessageToClipboard',
 	CopyRemoteBranchesUrl = 'gitlens.copyRemoteBranchesUrl',
 	CopyRemoteBranchUrl = 'gitlens.copyRemoteBranchUrl',

--- a/src/commands/copyCurrentBranch.ts
+++ b/src/commands/copyCurrentBranch.ts
@@ -1,13 +1,12 @@
 'use strict';
-
-import { env , TextEditor , Uri , window } from 'vscode';
-import { GitService } from '../git/gitService';
+import { env, TextEditor, Uri, window } from 'vscode';
+import { ActiveEditorCommand, command, Commands, getCommandUri, getRepoPathOrActiveOrPrompt } from './common';
+import { Container } from '../container';
 import { GitUri } from '../git/gitUri';
 import { Logger } from '../logger';
-import { ActiveEditorCommand, command, Commands, getCommandUri, getRepoPathOrActiveOrPrompt } from './common';
 
 @command()
-export class CopyCurrentBranch extends ActiveEditorCommand {
+export class CopyCurrentBranchCommand extends ActiveEditorCommand {
 	constructor() {
 		super(Commands.CopyCurrentBranch);
 	}
@@ -17,17 +16,17 @@ export class CopyCurrentBranch extends ActiveEditorCommand {
 
 		const gitUri = uri != null ? await GitUri.fromUri(uri) : undefined;
 
-		const repoPath = await getRepoPathOrActiveOrPrompt(gitUri, editor, 'Copy Current Branch');
+		const repoPath = await getRepoPathOrActiveOrPrompt(gitUri, editor, 'Copy Current Branch Name');
 		if (!repoPath) return;
 
-		const service = new GitService();
-
 		try {
-			const gitBranch = await service.getBranch(repoPath);
-			if (gitBranch?.name) await env.clipboard.writeText(gitBranch?.name);
+			const branch = await Container.git.getBranch(repoPath);
+			if (branch?.name) {
+				await env.clipboard.writeText(branch.name);
+			}
 		} catch (ex) {
-			Logger.error(ex, 'CopyCurrentBranch');
-			void window.showErrorMessage('Unable to copy current branch. See output channel for more details');
+			Logger.error(ex, 'CopyCurrentBranchCommand');
+			void window.showErrorMessage('Unable to copy current branch name. See output channel for more details');
 		}
 	}
 }

--- a/src/commands/copyCurrentBranch.ts
+++ b/src/commands/copyCurrentBranch.ts
@@ -1,0 +1,33 @@
+'use strict';
+
+import { env , TextEditor , Uri , window } from 'vscode';
+import { GitService } from '../git/gitService';
+import { GitUri } from '../git/gitUri';
+import { Logger } from '../logger';
+import { ActiveEditorCommand, command, Commands, getCommandUri, getRepoPathOrActiveOrPrompt } from './common';
+
+@command()
+export class CopyCurrentBranch extends ActiveEditorCommand {
+	constructor() {
+		super(Commands.CopyCurrentBranch);
+	}
+
+	async execute(editor?: TextEditor, uri?: Uri) {
+		uri = getCommandUri(uri, editor);
+
+		const gitUri = uri != null ? await GitUri.fromUri(uri) : undefined;
+
+		const repoPath = await getRepoPathOrActiveOrPrompt(gitUri, editor, 'Copy Current Branch');
+		if (!repoPath) return;
+
+		const service = new GitService();
+
+		try {
+			const gitBranch = await service.getBranch(repoPath);
+			if (gitBranch?.name) await env.clipboard.writeText(gitBranch?.name);
+		} catch (ex) {
+			Logger.error(ex, 'CopyCurrentBranch');
+			void window.showErrorMessage('Unable to copy current branch. See output channel for more details');
+		}
+	}
+}


### PR DESCRIPTION
# Description

### Summary of Changes
- Registers a command to bind a command id under the namespace `gitlens.views.branches`
- Adds a command contribution to make it available in the Command Palette
- Registers an onCommand activationEvent
- Uses GitService and env to copy the name to clipboard

### Background and Motivation
I love using GitLens and it works great when managing multiple repositories and multiple branches. Given the large number of branches in my repos, I would find it extremely convenient to have a command from the Command Palette that copies the name of the currently checked out branch. I do this so many times in a day in order to paste it in trackers and pull requests.

While this can be done using the copy command in the branchesView, it will save having to open that view and scroll through the hundreds of branches to find the one with the checkmark next to it.

### Related Issue: https://github.com/eamodio/vscode-gitlens/issues/1306

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
