### PR TITLE
Fixes #1328 - Adds support for reading file history for files which o…

### DIFF
--- a/src/git/gitUri.ts
+++ b/src/git/gitUri.ts
@@ -1,4 +1,5 @@
 'use strict';
+import * as fs from 'fs';
 import * as paths from 'path';
 import { Uri } from 'vscode';
 import { UriComparer } from '../comparers';
@@ -258,6 +259,15 @@ export class GitUri extends ((Uri as any) as UriEx) {
 	})
 	static async fromUri(uri: Uri): Promise<GitUri> {
 		if (GitUri.is(uri)) return uri;
+
+		const uriPath = uri.fsPath;
+		const realPath = fs.realpathSync(uriPath);
+		if (uriPath !== realPath) {
+			// If we got here, it means the original URI is to a symbolic link, so we create a new one using the real location.
+			const newUri = Uri.file(realPath);
+
+			return this.fromUri(newUri);
+		}
 
 		if (!Container.git.isTrackable(uri)) return new GitUri(uri);
 


### PR DESCRIPTION
# Description

Fixes #1328 - Adds support for reading the file history for files which originate from symlinks

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
