### PR TITLE
Fixes #1045 - Correctly resolve mapped drive on Windows

### DIFF
--- a/src/git/gitService.ts
+++ b/src/git/gitService.ts
@@ -3231,7 +3231,7 @@ export class GitService implements Disposable {
 
 						try {
 							const networkPath = await new Promise<string | undefined>(resolve =>
-								fs.realpath.native(`${letter}:`, { encoding: 'utf8' }, (err, resolvedPath) =>
+								fs.realpath.native(`${letter}:\\`, { encoding: 'utf8' }, (err, resolvedPath) =>
 									resolve(err != null ? undefined : resolvedPath),
 								),
 							);


### PR DESCRIPTION
# Description

`fs.realpath.native` in NodeJS uses the Win32 API function `GetFinalPathNameByHandle()` on Windows hosts,
therefore a given path must follow the guidelines for Win32 API file functions.
Drive letters on Windows need to end on a backslash according to the Win32 File Naming Conventions (https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file)
Omitting the backslash results in Windows treating the remaining path components as a relative path starting from the current directory on the specified disk (https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#fully-qualified-vs-relative-paths)

I tested this implementation for several repositories on Windows 10 using:
- [x] Repositories on UNC path
- [x] Repositories on mapped drive
- [x] Repositories on local drive

# Checklist

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses