### PR TITLE
Fixes #1335 - improve contributors view. Order by recent commit and use all refs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1961,6 +1961,12 @@
 					"markdownDescription": "Specifies whether to show pull requests (if any) associated with commits in the _Contributors_ view. Requires a connection to a supported remote service (e.g. GitHub)",
 					"scope": "window"
 				},
+				"gitlens.views.contributors.preferUpstream": {
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "Specifies whether to use the upstream remote for contributors details",
+					"scope": "window"
+				},
 				"gitlens.views.defaultItemLimit": {
 					"type": "number",
 					"default": 10,

--- a/src/git/git.ts
+++ b/src/git/git.ts
@@ -748,6 +748,7 @@ export namespace Git {
 			reverse,
 			similarityThreshold,
 			since,
+			all
 		}: {
 			authors?: string[];
 			format?: 'refs' | 'default';
@@ -756,6 +757,7 @@ export namespace Git {
 			reverse?: boolean;
 			similarityThreshold?: number | null;
 			since?: string;
+			all?: boolean;
 		},
 	) {
 		const params = [
@@ -784,6 +786,10 @@ export namespace Git {
 
 		if (authors != null && authors.length !== 0) {
 			params.push('--use-mailmap', ...authors.map(a => `--author=${a}`));
+		}
+
+		if (all) {
+			params.push('--all');
 		}
 
 		if (ref && !GitRevision.isUncommittedStaged(ref)) {

--- a/src/git/gitService.ts
+++ b/src/git/gitService.ts
@@ -1865,6 +1865,7 @@ export class GitService implements Disposable {
 			ref?: string;
 			reverse?: boolean;
 			since?: string;
+			all?: boolean;
 		} = {},
 	): Promise<GitLog | undefined> {
 		const limit = options.limit ?? Container.config.advanced.maxListItems ?? 0;
@@ -1877,6 +1878,7 @@ export class GitService implements Disposable {
 				reverse: options.reverse,
 				similarityThreshold: Container.config.advanced.similarityThreshold,
 				since: options.since,
+				all: options.all
 			});
 			const log = GitLogParser.parse(
 				data,

--- a/src/git/models/commit.ts
+++ b/src/git/models/commit.ts
@@ -11,6 +11,7 @@ import { GitReference, GitRevision, GitRevisionReference, PullRequest } from './
 export interface GitAuthor {
 	name: string;
 	lineCount: number;
+	email?: string;
 }
 
 export interface GitCommitLine {

--- a/src/git/parsers/logParser.ts
+++ b/src/git/parsers/logParser.ts
@@ -420,6 +420,7 @@ export class GitLogParser {
 					author = {
 						name: entry.author,
 						lineCount: 0,
+						email: entry.email
 					};
 					authors.set(entry.author, author);
 				}

--- a/src/views/nodes/contributorNode.ts
+++ b/src/views/nodes/contributorNode.ts
@@ -102,6 +102,7 @@ export class ContributorNode extends ViewNode<ContributorsView | RepositoriesVie
 			this._log = await Container.git.getLog(this.uri.repoPath!, {
 				limit: this.limit ?? this.view.config.defaultItemLimit,
 				authors: [`^${this.contributor.name} <${this.contributor.email}>$`],
+				all: true
 			});
 		}
 


### PR DESCRIPTION
## Ordering
Currently the contributors view hasn’t been very useful. The ordering was the most commits at the top. The problem that brings is you usually get people who don’t work on the project anymore at the top of the list and those you want to collaborate with half way down. This PR changes the ordering by most recent commit.

There is a limit on commits searched (the last 200). So this may show less contributors than before. A setting could be made to adjust this.

## Search all refs
The contributors view only checked the active remote. So if you added someone’s remote (like in the github pull request extension when you checkout someone’s PR) it wasn’t reflected in the contributors view. This PR fixes that by searching all refs in git log

- [ ] Show `You` correctly in results of Authors
- [ ] Add setting to adjust how many commits to look back (default 200)
- [ ] Update documentation

This could be made to be more efficient if we have a separate parser and formatter for contributors (which uses formatting to only get contributors like `git log --format="%an %ae"`). Then commits won't be fetched and thrown away.
This would also allow us to show more contributors than now because the command would return quicker

I don't see it as a blocker though, and is something that can be improved on.

fixes #1335