### PR TITLE
Fixes #1357 Corrects the compare functions

### DIFF
--- a/src/git/models/branch.ts
+++ b/src/git/models/branch.ts
@@ -63,7 +63,7 @@ export class GitBranch implements GitBranchReference {
 						(a.name === 'master' ? -1 : 1) - (b.name === 'master' ? -1 : 1) ||
 						(a.name === 'develop' ? -1 : 1) - (b.name === 'develop' ? -1 : 1) ||
 						(b.remote ? -1 : 1) - (a.remote ? -1 : 1) ||
-						b.name.localeCompare(a.name, undefined, { numeric: true, sensitivity: 'base' }),
+						a.name.localeCompare(b.name, undefined, { numeric: true, sensitivity: 'base' }),
 				);
 			default:
 				return branches.sort(
@@ -74,7 +74,7 @@ export class GitBranch implements GitBranchReference {
 						(a.name === 'master' ? -1 : 1) - (b.name === 'master' ? -1 : 1) ||
 						(a.name === 'develop' ? -1 : 1) - (b.name === 'develop' ? -1 : 1) ||
 						(b.remote ? -1 : 1) - (a.remote ? -1 : 1) ||
-						a.name.localeCompare(b.name, undefined, { numeric: true, sensitivity: 'base' }),
+						b.name.localeCompare(a.name, undefined, { numeric: true, sensitivity: 'base' }),
 				);
 		}
 	}

--- a/src/git/models/tag.ts
+++ b/src/git/models/tag.ts
@@ -32,11 +32,11 @@ export class GitTag implements GitTagReference {
 				return tags.sort((a, b) => b.date.getTime() - a.date.getTime());
 			case TagSorting.NameAsc:
 				return tags.sort((a, b) =>
-					b.name.localeCompare(a.name, undefined, { numeric: true, sensitivity: 'base' }),
+					a.name.localeCompare(b.name, undefined, { numeric: true, sensitivity: 'base' }),
 				);
 			default:
 				return tags.sort((a, b) =>
-					a.name.localeCompare(b.name, undefined, { numeric: true, sensitivity: 'base' }),
+					b.name.localeCompare(a.name, undefined, { numeric: true, sensitivity: 'base' }),
 				);
 		}
 	}


### PR DESCRIPTION
# Description

Corrects the compare functions that use String#localeCompare.  Fixes #1357

<!--
Please include a summary of the changes and which issue will be addressed. Please also include relevant motivation and context.
-->

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
