### PR TITLE
Correct "Toggle File Changes" command name in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Here are just some of the **features** that GitLens provides,
 </p>
 
 - Adds an on-demand, [customizable](#gutter-changes-settings- 'Jump to the Gutter Changes settings') and [themable](#themable-colors- 'Jump to Themable Colors'), **gutter changes annotation** to highlight any local (unpublished) changes or lines changed by the most recent commit
-  - Adds _Toggle File Changes Annotations_ command (`gitlens.toggleFileChanges`) to toggle the changes annotations on and off
+  - Adds _Toggle File Changes_ command (`gitlens.toggleFileChanges`) to toggle the changes annotations on and off
   - Press `Escape` to turn off the annotations
 
 ## Gutter Heatmap [#](#gutter-heatmap- 'Gutter Heatmap')


### PR DESCRIPTION
# Description

Corrects "Toggle File Changes Annotations" to match actual command name which is "Toggle File Changes".

# Checklist

<!-- Please check off the following -->

- [X ] I have followed the guidelines in the Contributing document
- [ X] My changes follow the coding style of this project
- [X] My changes build without any errors or warnings
- [X] My changes have been formatted and linted
- [X] My changes include any required corresponding changes to the documentation
- [X ] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [X] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
