### PR TITLE
[fix] Fixes Azure DevOps link formats. Fixes #1439

### DIFF
--- a/src/git/remotes/azure-devops.ts
+++ b/src/git/remotes/azure-devops.ts
@@ -132,15 +132,15 @@ export class AzureDevOpsRemote extends RemoteProvider {
 		let line;
 		if (range != null) {
 			if (range.start.line === range.end.line) {
-				line = `&line=${range.start.line}`;
+				line = `&line=${range.start.line}&lineStartColumn=${range.start.character + 1}&lineEndColumn=${range.end.character + 1}`;
 			} else {
-				line = `&line=${range.start.line}&lineEnd=${range.end.line}`;
+				line = `&line=${range.start.line}&lineEnd=${range.end.line}&lineStartColumn=${range.start.character + 1}&lineEndColumn=${range.end.character + 1}`;
 			}
 		} else {
 			line = '';
 		}
 
-		if (sha) return this.encodeUrl(`${this.baseUrl}/commit/${sha}/?_a=contents&path=/${fileName}${line}`);
+		if (sha) return this.encodeUrl(`${this.baseUrl}?path=${fileName}&version=GC${sha}${line}&_a=contents`);
 		if (branch) return this.encodeUrl(`${this.baseUrl}/?path=/${fileName}&version=GB${branch}&_a=contents${line}`);
 		return this.encodeUrl(`${this.baseUrl}?path=/${fileName}${line}`);
 	}


### PR DESCRIPTION
# Description
Currently, the Copy As -> Copy Remote File Url command for an Azure DevOps repo does not result in an URL that will open the file. This closes #1439 

# Checklist

<!-- Please check off the following -->

- [x] I have followed the guidelines in the Contributing document
- [x] My changes follow the coding style of this project
- [x] My changes build without any errors or warnings
- [x] My changes have been formatted and linted
- [x] My changes include any required corresponding changes to the documentation
- [x] My changes have been rebased and squashed to the minimal number (typically 1) of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixes $XXX -` or `Closes #XXX -` prefix to auto-close the issue that your PR addresses
